### PR TITLE
[FE] feat : 회원가입(SignUpPage) 페이지 구현

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",
     "react-scripts": "5.0.1",
+    "sweetalert2": "^11.10.5",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -71,6 +71,9 @@ dependencies:
   react-scripts:
     specifier: 5.0.1
     version: 5.0.1(@babel/plugin-syntax-flow@7.23.3)(@babel/plugin-transform-react-jsx@7.23.4)(eslint@8.56.0)(react@18.2.0)(typescript@4.9.5)
+  sweetalert2:
+    specifier: ^11.10.5
+    version: 11.10.5
   typescript:
     specifier: ^4.9.5
     version: 4.9.5
@@ -9815,6 +9818,10 @@ packages:
       csso: 4.2.0
       picocolors: 1.0.0
       stable: 0.1.8
+    dev: false
+
+  /sweetalert2@11.10.5:
+    resolution: {integrity: sha512-q9eE3EKhMcpIDU/Xcz7z5lk8axCGkgxwK47gXGrrfncnBJWxHPPHnBVAjfsVXcTt8Yi8U6HNEcBRSu+qGeyFdA==}
     dev: false
 
   /symbol-tree@3.2.4:

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -2,12 +2,14 @@ import './App.css';
 import { Route, Routes } from 'react-router-dom';
 import Test from './Test';
 import LoginPage from './pages/LoginPage';
+import SignUpPage from './pages/SignUpPage';
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Test />} />
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/sign-up" element={<SignUpPage />} />
     </Routes>
   );
 }

--- a/front/src/atoms/Header.tsx
+++ b/front/src/atoms/Header.tsx
@@ -11,7 +11,7 @@ import { IHeader } from '../types/components/Header.types';
 function Header(props: IHeader) {
   const navigate = useNavigate();
   return (
-    <div className="fixed top-0 w-full py-[15px] flex">
+    <div className="fixed top-0 w-full py-[15px] flex bg-white">
       <FontAwesomeIcon
         icon={faAngleLeft}
         onClick={() => navigate(-1)}

--- a/front/src/atoms/InputPassword.tsx
+++ b/front/src/atoms/InputPassword.tsx
@@ -4,7 +4,11 @@ import {
   ICheckArea,
   IInputPassword,
 } from '../types/components/InputPassword.types';
-
+import {
+  isLowerCase as isRightLowerCase,
+  isUpperCase as isRightUpperCase,
+  isSpecialCharacter as isRightSpecialCharacter,
+} from '../util/passwordCheck';
 /**
  * @param props
  * @returns
@@ -53,36 +57,12 @@ function InputPassword(props: IInputPassword) {
         alt="비밀번호 입력창"
       />
       <CheckArea
-        isLowerCase={isLowerCase(props.value)}
-        isSpecialCharacter={isSpecialCharacter(props.value)}
-        isUpperCase={isUpperCase(props.value)}
+        isLowerCase={isRightLowerCase(props.value)}
+        isSpecialCharacter={isRightSpecialCharacter(props.value)}
+        isUpperCase={isRightUpperCase(props.value)}
       />
     </div>
   );
 }
-
-const isUpperCase = (password: string | undefined) => {
-  if (password === undefined) return false;
-  // 정규표현식 /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,16}$/
-  const upperRegex = /^(?=.*[A-Z]).{1,}$/;
-
-  return upperRegex.test(password);
-};
-
-const isSpecialCharacter = (password: string | undefined) => {
-  if (password === undefined) return false;
-  // 정규표현식 /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,16}$/
-
-  const speciatlChacracterRegex = /^(?=.*[!@#$%^&*?_]).{1,}$/;
-  return speciatlChacracterRegex.test(password);
-};
-
-const isLowerCase = (password: string | undefined) => {
-  if (password === undefined) return false;
-  // 정규표현식 /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,16}$/
-
-  const lowerRegex = /^(?=.*[a-z]).{1,}$/;
-  return lowerRegex.test(password);
-};
 
 export default InputPassword;

--- a/front/src/atoms/InputText.tsx
+++ b/front/src/atoms/InputText.tsx
@@ -12,15 +12,15 @@ import { IInputText, ISupoortText } from '../types/components/InputText.types';
 
 const SupportText = (props: ISupoortText) => {
   if (props.isSuccess === -1) {
-    return <p />;
+    return <p className="mx-3 font-sm py-3 invisible">empty</p>;
   }
   if (props.isSuccess === 1) {
     return (
-      <p className="text-left font-sm text-correct mx-3 py-3">{`${props.successText}`}</p>
+      <p className="text-left font-sm text-correct mx-2 py-3">{`${props.successText}`}</p>
     );
   }
   return (
-    <p className="text-left font-sm text-error py-3">{`${props.failText}`}</p>
+    <p className="text-left font-sm text-error mx-2 py-3">{`${props.failText}`}</p>
   );
 };
 
@@ -40,7 +40,7 @@ function InputText(props: IInputText) {
         <input
           type={props.type}
           placeholder={props.placeholder}
-          className="w-full placeholder:font-ggTitle placeholder:text-sm font-sm rounded-small border-none focus:outline-none"
+          className="w-full placeholder:font-ggTitle placeholder:text-sm disabled:bg-white font-sm rounded-small border-none focus:outline-none"
           onChange={e => props.setValue(e.target.value)}
           value={props.value}
           alt={`${props.type} 입력창`}
@@ -54,9 +54,9 @@ function InputText(props: IInputText) {
       </div>
       {props.hasSupport && (
         <SupportText
-          isSuccess={props.isSuccess}
-          successText={props.successText}
-          failText={props.failText}
+          isSuccess={props.isSuccess ?? -1}
+          successText={props.successText ?? ''}
+          failText={props.failText ?? ''}
         />
       )}
     </div>

--- a/front/src/atoms/RectangleButton.tsx
+++ b/front/src/atoms/RectangleButton.tsx
@@ -5,7 +5,7 @@ function RectangleButton(props: IRectangleButton) {
     <button
       type="button"
       onClick={props.onClick}
-      className={`${props.isCancle ? 'bg-gray' : 'bg-primary'} rounded-[4px] w-full h-[45px]`}
+      className={`${props.isCancle ? 'bg-gray' : 'bg-primary'} rounded-[4px] h-[45px] ${props.customClass}`}
     >
       <span
         className={`text-xl font-bold ${props.isCancle ? 'text-black' : 'text-white'}`}

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -35,6 +35,12 @@
   }
 }
 
+@layer components {
+  .base-bold {
+    @apply font-bold text-base mb-[18px];
+  }
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/front/src/jotai/signUpAtom.ts
+++ b/front/src/jotai/signUpAtom.ts
@@ -1,0 +1,99 @@
+/**
+ * 회원가입에서 관리하는 정보
+ * signUpAtom : initialAtom
+ * setEmail : 이메일 갱신 set
+ * setCode : 인증코드 갱신
+ * plusSignUpLevel : signUp 단계 상향
+ * minusSignUpLevel : signUp 단계 하향
+ */
+
+import { atom, useAtomValue, useSetAtom } from 'jotai';
+import { ISignUpPage } from '../types/pages/SignUpPage.types';
+
+const signUpAtom = atom<ISignUpPage>({
+  email: '',
+  password: '',
+  confirmPassword: '',
+  code: '',
+  nickname: '',
+  signUpLevel: 0,
+});
+
+// setEmail
+const setEmail = atom(null, (get, set, email: string) => {
+  const signUpStatus = {
+    ...get(signUpAtom),
+    email,
+  };
+  set(signUpAtom, signUpStatus);
+});
+// setCode
+const setCode = atom(null, (get, set, code: string) => {
+  const signUpStatus = {
+    ...get(signUpAtom),
+    code,
+  };
+  set(signUpAtom, signUpStatus);
+});
+
+// signUpLevel 증가
+const plusSignUpLevel = atom(null, (get, set) => {
+  const prev = { ...get(signUpAtom) };
+  const signUpStatus = {
+    ...prev,
+    signUpLevel: prev.signUpLevel + 1,
+  };
+  set(signUpAtom, signUpStatus);
+});
+
+// signUpLevel 감소
+const minusSignUpLevel = atom(null, (get, set) => {
+  const prev = { ...get(signUpAtom) };
+  const signUpStatus = {
+    ...prev,
+    signUpLevel: prev.signUpLevel - 1,
+  };
+  set(signUpAtom, signUpStatus);
+});
+
+// password 등록
+const setPassword = atom(null, (get, set, password: string) => {
+  const signUpStatus = {
+    ...get(signUpAtom),
+    password,
+  };
+  set(signUpAtom, signUpStatus);
+});
+
+// 비밀번호 확인
+const setConfirmPassword = atom(null, (get, set, confirmPassword: string) => {
+  const signUpStatus = {
+    ...get(signUpAtom),
+    confirmPassword,
+  };
+  set(signUpAtom, signUpStatus);
+});
+
+// nickname 등록
+const setNickname = atom(null, (get, set, nickname: string) => {
+  const signUpStatus = {
+    ...get(signUpAtom),
+    nickname,
+  };
+  set(signUpAtom, signUpStatus);
+});
+
+export const useSetEmailAtom = () => useSetAtom(setEmail);
+export const useSetCodeAtom = () => useSetAtom(setCode);
+export const usePlusSignUpLevelAtom = () => useSetAtom(plusSignUpLevel);
+export const useMinusSignUpLevelAtom = () => useSetAtom(minusSignUpLevel);
+export const useRegistDataAtom = () => useAtomValue(signUpAtom);
+export const useSetPasswordAtom = () => useSetAtom(setPassword);
+export const useSetConfirmPasswordAtom = () => useSetAtom(setConfirmPassword);
+export const useSetNicknameAtom = () => useSetAtom(setNickname);
+
+// 고민 : 여러가지 방법?
+// 1. 지금과 같은 방법
+// 2. setAtom 분리하지 말고 통합 setAtom하나만 놓은 다음에, organism 코드에서 각각 알아서 넣기 (근데 이건 메인 코드가 길어지니까 내가 불호)
+// 3. 아니면 저 통합 atom 말고 initialAtom 자체를 분리하는거임 (atom 파일의 분리)
+// 1이 걱정되는건 atom 파일 코드 길이가 너무 커지는거? 나중에 성능 테스트할때 로딩 속도를 보면 좋을듯

--- a/front/src/organisms/RegistEmail.tsx
+++ b/front/src/organisms/RegistEmail.tsx
@@ -1,0 +1,49 @@
+import InputText from '../atoms/InputText';
+import RectangleButton from '../atoms/RectangleButton';
+// import { IRegistEmail } from '../types/organisms/RegistEmail.type';
+import {
+  useSetCodeAtom,
+  useSetEmailAtom,
+  usePlusSignUpLevelAtom,
+  useRegistDataAtom,
+} from '../jotai/signUpAtom';
+
+function RegistEmail() {
+  const registData = useRegistDataAtom();
+  const setEmail = useSetEmailAtom();
+  const setCode = useSetCodeAtom();
+  const plusSignUpLevel = usePlusSignUpLevelAtom();
+
+  return (
+    <div className="h-screen flex flex-col justify-center px-[30px]">
+      <p className="font-bold text-base mb-[18px] ml-1"> 사용할 이메일</p>
+      <InputText
+        type="text"
+        hasSupport={false}
+        placeholder="이메일"
+        setValue={setEmail}
+        customClass="mb-10"
+        value={registData.email}
+      />
+      {registData.signUpLevel > 0 && (
+        <p className="font-bold text-base mb-[18px] ml-1"> 인증코드 입력</p>
+      )}
+      {registData.signUpLevel > 0 && (
+        <InputText
+          type="text"
+          hasSupport={false}
+          placeholder="인증코드"
+          setValue={setCode}
+          value={registData.code}
+        />
+      )}
+      <RectangleButton
+        text="다음 단계로"
+        onClick={plusSignUpLevel}
+        customClass="fixed bottom-20 w-[calc(100%-60px)]"
+      />
+    </div>
+  );
+}
+
+export default RegistEmail;

--- a/front/src/organisms/RegistPassword.tsx
+++ b/front/src/organisms/RegistPassword.tsx
@@ -1,0 +1,117 @@
+/**
+ * RegistPassword : 회원가입 과정 중, 비밀번호 및 닉네임 등록 관리 컴포넌트
+ * @returns
+ */
+
+import { useNavigate } from 'react-router-dom';
+import Swal from 'sweetalert2';
+import InputPassword from '../atoms/InputPassword';
+import InputText from '../atoms/InputText';
+import RectangleButton from '../atoms/RectangleButton';
+import { isRightPassword } from '../util/passwordCheck';
+import {
+  useSetPasswordAtom,
+  useSetConfirmPasswordAtom,
+  useSetNicknameAtom,
+  useRegistDataAtom,
+} from '../jotai/signUpAtom';
+
+function RegistPassword() {
+  const registData = useRegistDataAtom();
+  const setPassword = useSetPasswordAtom();
+  const setConfirmPassword = useSetConfirmPasswordAtom();
+  const setNickname = useSetNicknameAtom();
+  const navigate = useNavigate();
+  const handleSignUpButton = () => {
+    // 닉네임 체크?
+    // 비밀번호 체크
+    if (!isRightPassword(registData.password)) {
+      Swal.fire({
+        icon: 'warning',
+        text: '비밀번호가 올바르지 않습니다.',
+        width: '300px',
+        confirmButtonText: '돌아가기',
+        confirmButtonColor: '#787D85',
+      });
+      return;
+    }
+    // 비밀번호 일치성 체크
+    if (
+      handleSuccessOfConfirmPassword(
+        registData.password,
+        registData.confirmPassword,
+      ) !== 1
+    ) {
+      Swal.fire({
+        icon: 'warning',
+        text: '입력한 비밀번호가 다릅니다!',
+        width: '300px',
+        confirmButtonText: '돌아가기',
+        confirmButtonColor: '#787D85',
+      });
+      return;
+    }
+    navigate('/login');
+  };
+  return (
+    <div className="h-screen flex flex-col justify-center px-[30px]">
+      <p className="base-bold ml-1">이메일</p>
+      <InputText
+        type="text"
+        placeholder="아이디"
+        value={registData.email}
+        setValue={() => {}}
+        hasSupport={false}
+        disabled
+        customClass="mb-5"
+      />
+      <p className="base-bold mb-5 ml-1">
+        새로 설정할 비밀번호를 입력해주세요.
+      </p>
+      <InputPassword
+        setValue={setPassword}
+        value={registData.password}
+        customClass="mb-5"
+      />
+      <p className="base-bold ml-1">비밀번호를 다시 입력해주세요.</p>
+      <InputText
+        type="password"
+        hasSupport
+        isSuccess={handleSuccessOfConfirmPassword(
+          registData.password,
+          registData.confirmPassword,
+        )}
+        successText="비밀번호가 일치합니다."
+        failText="비밀번호가 일치하지 않습니다."
+        placeholder="비밀번호 확인"
+        setValue={setConfirmPassword}
+        value={registData.confirmPassword}
+      />
+      <p className="base-bold ml-1">닉네임</p>
+      <InputText
+        type="text"
+        hasSupport={false}
+        placeholder="닉네임"
+        setValue={setNickname}
+        value={registData.nickname}
+      />
+      <RectangleButton
+        text="확인"
+        onClick={handleSignUpButton}
+        customClass="fixed bottom-20 w-[calc(100%-60px)]"
+      />
+    </div>
+  );
+}
+
+const handleSuccessOfConfirmPassword = (origin: string, target: string) => {
+  if (target.length === 0) {
+    return -1;
+  }
+  if (origin === target) {
+    return 1;
+  }
+  return 0;
+};
+
+export default RegistPassword;

--- a/front/src/pages/LoginPage.tsx
+++ b/front/src/pages/LoginPage.tsx
@@ -57,9 +57,13 @@ function LoginPage() {
       >
         아이디 또는 비밀번호 정보가 잘못되었습니다.
       </p>
-      <RectangleButton text="로그인" onClick={() => SubmitLogin()} />
+      <RectangleButton
+        text="로그인"
+        onClick={() => SubmitLogin()}
+        customClass="w-full"
+      />
       <div className="flex justify-center items-center my-[15px]">
-        <Link to="/" className="mr-4 text-sm">
+        <Link to="/sign-up" className="mr-4 text-sm">
           회원가입
         </Link>{' '}
         |{' '}

--- a/front/src/pages/SignUpPage.tsx
+++ b/front/src/pages/SignUpPage.tsx
@@ -1,0 +1,17 @@
+import Header from '../atoms/Header';
+import RegistEmail from '../organisms/RegistEmail';
+import { useRegistDataAtom } from '../jotai/signUpAtom';
+import RegistPassword from '../organisms/RegistPassword';
+
+function SignUpPage() {
+  const registData = useRegistDataAtom();
+
+  return (
+    <div className="bg-background">
+      <Header title="회원가입" />
+      {registData.signUpLevel < 2 ? <RegistEmail /> : <RegistPassword />}
+    </div>
+  );
+}
+
+export default SignUpPage;

--- a/front/src/types/components/InputText.types.ts
+++ b/front/src/types/components/InputText.types.ts
@@ -1,10 +1,10 @@
 export interface IInputText {
   type: string;
   placeholder: string;
-  successText: string;
-  failText: string;
+  successText?: string;
+  failText?: string;
   value?: string;
-  isSuccess: number;
+  isSuccess?: number;
   disabled?: boolean;
   setValue: (value: string) => void;
   hasButton?: boolean;

--- a/front/src/types/components/RectangleButton.types.ts
+++ b/front/src/types/components/RectangleButton.types.ts
@@ -2,4 +2,5 @@ export interface IRectangleButton {
   text: string;
   isCancle?: boolean;
   onClick: () => void;
+  customClass?: string;
 }

--- a/front/src/types/pages/SignUpPage.types.ts
+++ b/front/src/types/pages/SignUpPage.types.ts
@@ -1,0 +1,8 @@
+export interface ISignUpPage {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  code: string;
+  nickname: string;
+  signUpLevel: number;
+}

--- a/front/src/util/passwordCheck.ts
+++ b/front/src/util/passwordCheck.ts
@@ -1,0 +1,31 @@
+export const isUpperCase = (password: string | undefined) => {
+  if (password === undefined) return false;
+  // 정규표현식 /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,16}$/
+  const upperRegex = /^(?=.*[A-Z]).{1,}$/;
+
+  return upperRegex.test(password);
+};
+
+export const isSpecialCharacter = (password: string | undefined) => {
+  if (password === undefined) return false;
+  // 정규표현식 /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,16}$/
+
+  const speciatlChacracterRegex = /^(?=.*[!@#$%^&*?_]).{1,}$/;
+  return speciatlChacracterRegex.test(password);
+};
+
+export const isLowerCase = (password: string | undefined) => {
+  if (password === undefined) return false;
+  // 정규표현식 /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,16}$/
+
+  const lowerRegex = /^(?=.*[a-z]).{1,}$/;
+  return lowerRegex.test(password);
+};
+
+export const isRightPassword = (password: string | undefined) => {
+  return (
+    isUpperCase(password) &&
+    isLowerCase(password) &&
+    isSpecialCharacter(password)
+  );
+};

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  mode: 'jit',
   theme: {
     colors: {
       black: '#001F2A',


### PR DESCRIPTION
## 개요 :mag:

회원가입 프로세스를 위한 회원가입 페이지 구현

## 작업사항 :memo:

- 회원가입 단계를 organism으로 이메일 인증, 비밀번호 및 닉네임 등록으로 분리
- 회원가입의 정보를 jotai로 상태관리
- 회원가입 최종단계에서 에러 발생할 경우 (잘못된 비밀번호, 비밀번호 불일치) Sweetalert2을 통해 사용자와 상호작용
