### PR TITLE
[FE] feature : 비밀번호 재설정 페이지 구현

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,24 +8,34 @@
       "name": "front",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.5.1",
+        "@fortawesome/free-regular-svg-icons": "^6.5.1",
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "@tanstack/react-query": "^5.22.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
-        "@types/node": "^16.18.74",
+        "@types/node": "^16.18.75",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
-        "@typescript-eslint/parser": "^6.19.1",
+        "@typescript-eslint/eslint-plugin": "^5.62.0",
+        "@typescript-eslint/parser": "^5.62.0",
+        "axios": "^1.6.7",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-airbnb-typescript": "^17.1.0",
-        "jotai": "^2.6.2",
+        "jotai": "^2.6.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.0",
         "react-scripts": "5.0.1",
+        "sweetalert2": "^11.10.5",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@tanstack/eslint-plugin-query": "^5.20.1",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
@@ -2392,6 +2402,63 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-m6ShXn+wvqEU69wSP84coxLbNl7sGVZb+Ca+XZq6k30SzuP3X4TfPqtycgUh9ASwlNh5OfQCd8pDIWxl+O+LlQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -3361,6 +3428,14 @@
         }
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.2.tgz",
+      "integrity": "sha512-+Rnav+CaoTE5QJc4Jcwh5toUpnVLKYbpU6Ys0zqbakqbaLQHeglLVHPfxOiQqdNmUy5C2lXz5dwC6tQNX2JW2Q==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -3677,6 +3752,170 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.20.1.tgz",
+      "integrity": "sha512-oIp7Wh90KHOm1FKCvcv87fiD2H96xo/crFrlhbvqBzR2f0tMEGOK/ANKMGNFQprd6BT6lyZhQPlOEkFdezsjIg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^6.20.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.24.1.tgz",
+      "integrity": "sha512-DZ6Nx9p7BhjkG50ayJ+MKPgff+lMeol7QYXkvuU5jr2ryW/4ok5eanaS9W5eooA4xN0A/GPHdLGOZGzArgf5Cg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.24.1.tgz",
+      "integrity": "sha512-4+09JEdO4d6+Gc8Y/g2M/MuxDK5IY0QV8+2wL2304wPKJgJ54cBbULd3nciJ5uvh/as8rrxx6s0mtIwpRuGd1g==",
+      "dependencies": {
+        "@tanstack/query-core": "5.24.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4190,9 +4429,9 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/node": {
-      "version": "16.18.74",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.74.tgz",
-      "integrity": "sha512-eEn8RkzZFcT0gb8qyi0CcfSOQnLE+NbGLIIaxGGmjn/N35v/C3M8ohxcpSlNlCv+H8vPpMGmrGDdCkzr8xu2tQ=="
+      "version": "16.18.86",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.86.tgz",
+      "integrity": "sha512-QMvdZf+ZTSiv7gspwhqbfB7Y5DmbYgCsUnakS8Ul9uRbJQehDKaM7SL+GbcDS003Lh7VK4YlelHsRm9HCv26eA=="
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.11",
@@ -4348,162 +4587,36 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.19.1.tgz",
-      "integrity": "sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==",
-      "peer": true,
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.19.1",
-        "@typescript-eslint/type-utils": "6.19.1",
-        "@typescript-eslint/utils": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/type-utils": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
-        "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.1.tgz",
-      "integrity": "sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==",
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.1.tgz",
-      "integrity": "sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==",
-      "peer": true,
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.1.tgz",
-      "integrity": "sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==",
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.1.tgz",
-      "integrity": "sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==",
-      "peer": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.19.1",
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/typescript-estree": "6.19.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.1.tgz",
-      "integrity": "sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==",
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
@@ -4525,123 +4638,29 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.1.tgz",
-      "integrity": "sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.19.1",
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/typescript-estree": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.1.tgz",
-      "integrity": "sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==",
-      "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.1.tgz",
-      "integrity": "sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==",
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.1.tgz",
-      "integrity": "sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==",
-      "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.1.tgz",
-      "integrity": "sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==",
-      "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -4661,154 +4680,29 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.1.tgz",
-      "integrity": "sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==",
-      "peer": true,
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.19.1",
-        "@typescript-eslint/utils": "6.19.1",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "*"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.1.tgz",
-      "integrity": "sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==",
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.1.tgz",
-      "integrity": "sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==",
-      "peer": true,
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.1.tgz",
-      "integrity": "sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==",
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/visitor-keys": "6.19.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.1.tgz",
-      "integrity": "sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==",
-      "peer": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.19.1",
-        "@typescript-eslint/types": "6.19.1",
-        "@typescript-eslint/typescript-estree": "6.19.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.1.tgz",
-      "integrity": "sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==",
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.19.1",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -5535,6 +5429,29 @@
       "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -7715,91 +7632,6 @@
       },
       "peerDependencies": {
         "eslint": "^8.0.0"
-      }
-    },
-    "node_modules/eslint-config-react-app/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
-      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/type-utils": "5.62.0",
-        "@typescript-eslint/utils": "5.62.0",
-        "debug": "^4.3.4",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "natural-compare-lite": "^1.4.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-config-react-app/node_modules/@typescript-eslint/parser": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-config-react-app/node_modules/@typescript-eslint/type-utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
-      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "@typescript-eslint/utils": "5.62.0",
-        "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/eslint-config-react-app/node_modules/eslint-plugin-jest": {
@@ -14991,6 +14823,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -15285,6 +15122,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.2.tgz",
+      "integrity": "sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==",
+      "dependencies": {
+        "@remix-run/router": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.2.tgz",
+      "integrity": "sha512-WgqxD2qySEIBPZ3w0sHH+PUAiamDeszls9tzqMPBDA1YYVucTBXLU7+gtRfcSnhe92A3glPnvSxK2dhNoAVOIQ==",
+      "dependencies": {
+        "@remix-run/router": "1.15.2",
+        "react-router": "6.22.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {
@@ -16890,6 +16757,15 @@
         "boolbase": "~1.0.0"
       }
     },
+    "node_modules/sweetalert2": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.10.5.tgz",
+      "integrity": "sha512-q9eE3EKhMcpIDU/Xcz7z5lk8axCGkgxwK47gXGrrfncnBJWxHPPHnBVAjfsVXcTt8Yi8U6HNEcBRSu+qGeyFdA==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -17179,11 +17055,12 @@
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
     "node_modules/ts-api-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
-      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
+      "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
+      "dev": true,
       "engines": {
-        "node": ">=16.13.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -3,13 +3,20 @@ import { Route, Routes } from 'react-router-dom';
 import Test from './Test';
 import LoginPage from './pages/LoginPage';
 import SignUpPage from './pages/SignUpPage';
+import ResetPasswordPage from './pages/ResetPasswordPage';
+import HeaderOnlyLayout from './layout/HeaderOnlyLayout';
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Test />} />
       <Route path="/login" element={<LoginPage />} />
-      <Route path="/sign-up" element={<SignUpPage />} />
+      <Route element={<HeaderOnlyLayout isSignUp />}>
+        <Route path="/sign-up" element={<SignUpPage />} />
+      </Route>
+      <Route element={<HeaderOnlyLayout isSignUp={false} />}>
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
+      </Route>
     </Routes>
   );
 }

--- a/front/src/jotai/signInData.ts
+++ b/front/src/jotai/signInData.ts
@@ -1,6 +1,6 @@
 /**
  * 회원가입에서 관리하는 정보
- * signUpAtom : initialAtom
+ * signInDataAtom : initialAtom
  * setEmail : 이메일 갱신 set
  * setCode : 인증코드 갱신
  * plusSignUpLevel : signUp 단계 상향
@@ -10,7 +10,7 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { ISignUpPage } from '../types/pages/SignUpPage.types';
 
-const signUpAtom = atom<ISignUpPage>({
+const signInDataAtom = atom<ISignUpPage>({
   email: '',
   password: '',
   confirmPassword: '',
@@ -19,78 +19,90 @@ const signUpAtom = atom<ISignUpPage>({
   signUpLevel: 0,
 });
 
+const initSignInDataAtom = atom(null, (get, set) => {
+  set(signInDataAtom, {
+    email: '',
+    password: '',
+    confirmPassword: '',
+    code: '',
+    nickname: '',
+    signUpLevel: 0,
+  });
+});
+
 // setEmail
 const setEmail = atom(null, (get, set, email: string) => {
   const signUpStatus = {
-    ...get(signUpAtom),
+    ...get(signInDataAtom),
     email,
   };
-  set(signUpAtom, signUpStatus);
+  set(signInDataAtom, signUpStatus);
 });
 // setCode
 const setCode = atom(null, (get, set, code: string) => {
   const signUpStatus = {
-    ...get(signUpAtom),
+    ...get(signInDataAtom),
     code,
   };
-  set(signUpAtom, signUpStatus);
+  set(signInDataAtom, signUpStatus);
 });
 
 // signUpLevel 증가
 const plusSignUpLevel = atom(null, (get, set) => {
-  const prev = { ...get(signUpAtom) };
+  const prev = { ...get(signInDataAtom) };
   const signUpStatus = {
     ...prev,
     signUpLevel: prev.signUpLevel + 1,
   };
-  set(signUpAtom, signUpStatus);
+  set(signInDataAtom, signUpStatus);
 });
 
 // signUpLevel 감소
 const minusSignUpLevel = atom(null, (get, set) => {
-  const prev = { ...get(signUpAtom) };
+  const prev = { ...get(signInDataAtom) };
   const signUpStatus = {
     ...prev,
     signUpLevel: prev.signUpLevel - 1,
   };
-  set(signUpAtom, signUpStatus);
+  set(signInDataAtom, signUpStatus);
 });
 
 // password 등록
 const setPassword = atom(null, (get, set, password: string) => {
   const signUpStatus = {
-    ...get(signUpAtom),
+    ...get(signInDataAtom),
     password,
   };
-  set(signUpAtom, signUpStatus);
+  set(signInDataAtom, signUpStatus);
 });
 
 // 비밀번호 확인
 const setConfirmPassword = atom(null, (get, set, confirmPassword: string) => {
   const signUpStatus = {
-    ...get(signUpAtom),
+    ...get(signInDataAtom),
     confirmPassword,
   };
-  set(signUpAtom, signUpStatus);
+  set(signInDataAtom, signUpStatus);
 });
 
 // nickname 등록
 const setNickname = atom(null, (get, set, nickname: string) => {
   const signUpStatus = {
-    ...get(signUpAtom),
+    ...get(signInDataAtom),
     nickname,
   };
-  set(signUpAtom, signUpStatus);
+  set(signInDataAtom, signUpStatus);
 });
 
 export const useSetEmailAtom = () => useSetAtom(setEmail);
 export const useSetCodeAtom = () => useSetAtom(setCode);
 export const usePlusSignUpLevelAtom = () => useSetAtom(plusSignUpLevel);
 export const useMinusSignUpLevelAtom = () => useSetAtom(minusSignUpLevel);
-export const useRegistDataAtom = () => useAtomValue(signUpAtom);
+export const useSignInDataAtom = () => useAtomValue(signInDataAtom);
 export const useSetPasswordAtom = () => useSetAtom(setPassword);
 export const useSetConfirmPasswordAtom = () => useSetAtom(setConfirmPassword);
 export const useSetNicknameAtom = () => useSetAtom(setNickname);
+export const useInitSignInDataAtom = () => useSetAtom(initSignInDataAtom);
 
 // 고민 : 여러가지 방법?
 // 1. 지금과 같은 방법

--- a/front/src/layout/HeaderOnlyLayout.tsx
+++ b/front/src/layout/HeaderOnlyLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import Header from '../atoms/Header';
+
+function HeaderOnlyLayout({ isSignUp }: { isSignUp: boolean }) {
+  return (
+    <div>
+      <Header title={`${isSignUp ? '회원가입' : '비밀번호 찾기'}`} />
+      <Outlet />
+    </div>
+  );
+}
+
+export default HeaderOnlyLayout;

--- a/front/src/organisms/RegistEmail.tsx
+++ b/front/src/organisms/RegistEmail.tsx
@@ -5,18 +5,34 @@ import {
   useSetCodeAtom,
   useSetEmailAtom,
   usePlusSignUpLevelAtom,
-  useRegistDataAtom,
-} from '../jotai/signUpAtom';
+  useSignInDataAtom,
+} from '../jotai/signInData';
+import { IRegistEmail } from '../types/organisms/RegistEmail.types';
 
-function RegistEmail() {
-  const registData = useRegistDataAtom();
+function Basebold({ text }: { text: string }) {
+  return <p className="font-bold text-base mb-[18px] ml-1">{text}</p>;
+}
+
+function RegistEmail(props: IRegistEmail) {
+  const registData = useSignInDataAtom();
   const setEmail = useSetEmailAtom();
   const setCode = useSetCodeAtom();
   const plusSignUpLevel = usePlusSignUpLevelAtom();
 
+  const handleNextButton = () => {
+    if (registData.signUpLevel === 0) {
+      // 여기에 Swal2로 이메일 확인하라는 문구 넣기
+      plusSignUpLevel();
+      return;
+    }
+    if (isCodeRight()) {
+      plusSignUpLevel();
+    }
+  };
   return (
     <div className="h-screen flex flex-col justify-center px-[30px]">
-      <p className="font-bold text-base mb-[18px] ml-1"> 사용할 이메일</p>
+      <Basebold text={props.isSignUp ? '사용할 이메일' : '작성한 이메일'} />
+
       <InputText
         type="text"
         hasSupport={false}
@@ -39,11 +55,15 @@ function RegistEmail() {
       )}
       <RectangleButton
         text="다음 단계로"
-        onClick={plusSignUpLevel}
+        onClick={handleNextButton}
         customClass="fixed bottom-20 w-[calc(100%-60px)]"
       />
     </div>
   );
 }
+
+const isCodeRight = () => {
+  return true;
+};
 
 export default RegistEmail;

--- a/front/src/organisms/RegistNickname.tsx
+++ b/front/src/organisms/RegistNickname.tsx
@@ -1,0 +1,52 @@
+import InputText from '../atoms/InputText';
+import RectangleButton from '../atoms/RectangleButton';
+import { useSetNicknameAtom, useSignInDataAtom } from '../jotai/signInData';
+
+function RegistNickname() {
+  const setNickname = useSetNicknameAtom();
+  const registData = useSignInDataAtom();
+
+  const handleOverlapCheck = () => {};
+
+  return (
+    <div className="h-screen flex flex-col justify-center px-[30px]">
+      <p className="base-bold ml-1">닉네임을 설정해주세요.</p>
+      <div className="flex gap-4">
+        <InputText
+          hasSupport
+          placeholder="닉네임"
+          setValue={setNickname}
+          type="text"
+          failText="중복된 닉네임이 있습니다."
+          isSuccess={isRightNickname(registData.nickname)}
+          successText="사용가능한 닉네임입니다."
+          value={registData.nickname}
+          customClass="flex-[1_1_content]"
+        />
+        <RectangleButton
+          onClick={handleOverlapCheck}
+          text="중복검사"
+          customClass="flex-[1_1_95px] h-[40px]"
+        />
+      </div>
+      <RectangleButton
+        onClick={() => {}}
+        text="확인"
+        customClass="fixed bottom-20 w-[calc(100%-60px)]"
+      />
+    </div>
+  );
+}
+
+const isRightNickname = (nickname: string) => {
+  // nickname 기반으로 API 보내고 그 결과 받아오기
+  if (nickname.length > 5) {
+    return 1;
+  }
+  if (nickname.length > 3) {
+    return 0;
+  }
+  return -1;
+};
+
+export default RegistNickname;

--- a/front/src/organisms/RegistPassword.tsx
+++ b/front/src/organisms/RegistPassword.tsx
@@ -12,18 +12,19 @@ import { isRightPassword } from '../util/passwordCheck';
 import {
   useSetPasswordAtom,
   useSetConfirmPasswordAtom,
-  // useSetNicknameAtom,
-  useRegistDataAtom,
-} from '../jotai/signUpAtom';
+  usePlusSignUpLevelAtom,
+  useSignInDataAtom,
+} from '../jotai/signInData';
 import { IRegistPassword } from '../types/organisms/RegistPassword.types';
 
 function RegistPassword(props: IRegistPassword) {
-  const registData = useRegistDataAtom();
+  const registData = useSignInDataAtom();
   const setPassword = useSetPasswordAtom();
   const setConfirmPassword = useSetConfirmPasswordAtom();
+  const plusSignUpLevelAtom = usePlusSignUpLevelAtom();
   // const setNickname = useSetNicknameAtom();
   const navigate = useNavigate();
-  const handleSignUpButton = () => {
+  const handleNextButton = () => {
     // 닉네임 체크?
     // 비밀번호 체크
     if (!isRightPassword(registData.password)) {
@@ -52,7 +53,11 @@ function RegistPassword(props: IRegistPassword) {
       });
       return;
     }
-    navigate('/login');
+    if (props.isSignUp) {
+      plusSignUpLevelAtom();
+    } else {
+      navigate('/login');
+    }
   };
   return (
     <div className="h-screen flex flex-col justify-center px-[30px]">
@@ -99,8 +104,8 @@ function RegistPassword(props: IRegistPassword) {
         value={registData.nickname}
       /> */}
       <RectangleButton
-        text="확인"
-        onClick={handleSignUpButton}
+        text="다음 단계로"
+        onClick={handleNextButton}
         customClass="fixed bottom-20 w-[calc(100%-60px)]"
       />
     </div>

--- a/front/src/organisms/RegistPassword.tsx
+++ b/front/src/organisms/RegistPassword.tsx
@@ -12,15 +12,16 @@ import { isRightPassword } from '../util/passwordCheck';
 import {
   useSetPasswordAtom,
   useSetConfirmPasswordAtom,
-  useSetNicknameAtom,
+  // useSetNicknameAtom,
   useRegistDataAtom,
 } from '../jotai/signUpAtom';
+import { IRegistPassword } from '../types/organisms/RegistPassword.types';
 
-function RegistPassword() {
+function RegistPassword(props: IRegistPassword) {
   const registData = useRegistDataAtom();
   const setPassword = useSetPasswordAtom();
   const setConfirmPassword = useSetConfirmPasswordAtom();
-  const setNickname = useSetNicknameAtom();
+  // const setNickname = useSetNicknameAtom();
   const navigate = useNavigate();
   const handleSignUpButton = () => {
     // 닉네임 체크?
@@ -55,16 +56,18 @@ function RegistPassword() {
   };
   return (
     <div className="h-screen flex flex-col justify-center px-[30px]">
-      <p className="base-bold ml-1">이메일</p>
-      <InputText
-        type="text"
-        placeholder="아이디"
-        value={registData.email}
-        setValue={() => {}}
-        hasSupport={false}
-        disabled
-        customClass="mb-5"
-      />
+      {props.isSignUp && <p className="base-bold ml-1">이메일</p>}
+      {props.isSignUp && (
+        <InputText
+          type="text"
+          placeholder="아이디"
+          value={registData.email}
+          setValue={() => {}}
+          hasSupport={false}
+          disabled
+          customClass="mb-5"
+        />
+      )}
       <p className="base-bold mb-5 ml-1">
         새로 설정할 비밀번호를 입력해주세요.
       </p>
@@ -87,14 +90,14 @@ function RegistPassword() {
         setValue={setConfirmPassword}
         value={registData.confirmPassword}
       />
-      <p className="base-bold ml-1">닉네임</p>
+      {/* <p className="base-bold ml-1">닉네임</p>
       <InputText
         type="text"
         hasSupport={false}
         placeholder="닉네임"
         setValue={setNickname}
         value={registData.nickname}
-      />
+      /> */}
       <RectangleButton
         text="확인"
         onClick={handleSignUpButton}

--- a/front/src/pages/LoginPage.tsx
+++ b/front/src/pages/LoginPage.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import InputPassword from '../atoms/InputPassword';
 import InputText from '../atoms/InputText';
 import RectangleButton from '../atoms/RectangleButton';
-// import { useQuery } from '@tanstack/react-query';
 import { fetchLogin } from '../services/UserService';
 
 const TEST_CONTROL_LOGIN = false;
@@ -67,7 +66,7 @@ function LoginPage() {
           회원가입
         </Link>{' '}
         |{' '}
-        <Link to="/" className="ml-4 text-sm">
+        <Link to="/reset-password" className="ml-4 text-sm">
           비밀번호 찾기
         </Link>
       </div>

--- a/front/src/pages/ResetPasswordPage.tsx
+++ b/front/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import RegistEmail from '../organisms/RegistEmail';
+import { useSignInDataAtom, useInitSignInDataAtom } from '../jotai/signInData';
+import RegistPassword from '../organisms/RegistPassword';
+
+function ResetPasswordPage() {
+  const registData = useSignInDataAtom();
+  const setInitRegistData = useInitSignInDataAtom();
+
+  useEffect(() => {
+    setInitRegistData();
+  }, []);
+
+  return (
+    <div className="bg-background">
+      {registData.signUpLevel < 2 && <RegistEmail isSignUp={false} />}
+      {registData.signUpLevel === 2 && <RegistPassword isSignUp={false} />}
+    </div>
+  );
+}
+
+export default ResetPasswordPage;

--- a/front/src/pages/SignUpPage.tsx
+++ b/front/src/pages/SignUpPage.tsx
@@ -1,15 +1,22 @@
-import Header from '../atoms/Header';
+import { useEffect } from 'react';
 import RegistEmail from '../organisms/RegistEmail';
-import { useRegistDataAtom } from '../jotai/signUpAtom';
+import { useSignInDataAtom, useInitSignInDataAtom } from '../jotai/signInData';
 import RegistPassword from '../organisms/RegistPassword';
+import RegistNickname from '../organisms/RegistNickname';
 
 function SignUpPage() {
-  const registData = useRegistDataAtom();
+  const registData = useSignInDataAtom();
+  const setInitSignInData = useInitSignInDataAtom();
+
+  useEffect(() => {
+    setInitSignInData();
+  }, []);
 
   return (
     <div className="bg-background">
-      <Header title="회원가입" />
-      {registData.signUpLevel < 2 ? <RegistEmail /> : <RegistPassword />}
+      {registData.signUpLevel < 2 && <RegistEmail isSignUp />}
+      {registData.signUpLevel === 2 && <RegistPassword isSignUp />}
+      {registData.signUpLevel === 3 && <RegistNickname />}
     </div>
   );
 }

--- a/front/src/types/jotai/signInData.types.ts
+++ b/front/src/types/jotai/signInData.types.ts
@@ -1,0 +1,8 @@
+export interface ISignUpPage {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  code: string;
+  nickname: string;
+  signUpLevel: number;
+}

--- a/front/src/types/organisms/RegistEmail.types.ts
+++ b/front/src/types/organisms/RegistEmail.types.ts
@@ -1,0 +1,3 @@
+export interface IRegistEmail {
+  isSignUp: boolean;
+}

--- a/front/src/types/organisms/RegistPassword.types.ts
+++ b/front/src/types/organisms/RegistPassword.types.ts
@@ -1,0 +1,3 @@
+export interface IRegistPassword {
+  isSignUp?: boolean;
+}


### PR DESCRIPTION
## 개요 :mag:

비밀번호 재설정 페이지 구현

## 작업사항 :memo:

- App 에서 route 할 때 레이아웃을 통해 회원가입/비밀번호재설정 페이지를 나눔
- 회원가입/ 비밀번호 재설정이냐에 따라 이메일 입력 부분의 텍스트가 달라지는데, 이 부분에서 애로사항이 발생
  - outlet에 props로 전달한 페이지 종류 정보를 이용하여 RegistEmail을 갱신하려 했으나, 페이지 전화에 따라 리렌더링이 일어나지 않음
  - 결국 props로 전달하는게 아닌, 회원가입 or 비밀번호 재설정이냐에 따라 직접 값을 넣어줌으로서 변경 (애초에 리렌더링이 아닐 수 있음)
