### PR TITLE
[FE/feat] 검색 컴포넌트 흐름 구현

### DIFF
--- a/front/src/atoms/RectangleChip.tsx
+++ b/front/src/atoms/RectangleChip.tsx
@@ -8,7 +8,7 @@ import { IRectangleChip } from '../types/components/RectangleChip.types';
 
 function RectangleChip(props: IRectangleChip) {
   return (
-    <span className="bg-secondary my-auto rounded-small text-base py-[5px] px-2.5 border-secondary  border-[1.5px]">
+    <span className="bg-secondary-container my-auto rounded-small text-base py-[5px] px-2.5 border-secondary-container  border-[1.5px]">
       {props.text}
     </span>
   );

--- a/front/src/atoms/ToggleChip.tsx
+++ b/front/src/atoms/ToggleChip.tsx
@@ -12,8 +12,8 @@ function ToggleChip(props: IToggleChip) {
       type="button"
       onClick={props.onClick}
       className={`${
-        props.isClick ? 'bg-secondary' : 'bg-white'
-      } rounded-full text-base py-[5px] px-2.5 border-secondary  border-[1.5px]`}
+        props.isClick ? 'bg-secondary-container' : 'bg-white'
+      } rounded-full text-base py-[5px] px-2.5 border-secondary-container  border-[1.5px]`}
     >
       {props.text}
     </button>

--- a/front/src/constant/searchConstant.ts
+++ b/front/src/constant/searchConstant.ts
@@ -1,0 +1,11 @@
+export const CATEGORY_LIST = [
+  '전체',
+  '한식',
+  '일식',
+  '양식',
+  '중식',
+  '베트남',
+  '멕시코',
+];
+
+export const SORT_LIST = ['최신순', '평점순', 'Yummy순'];

--- a/front/src/jotai/searchData.ts
+++ b/front/src/jotai/searchData.ts
@@ -11,7 +11,7 @@ import {
 
 const searchData = atom<ISearchData>({
   keyword: '',
-  category: 0,
+  category: Array(10).fill(false),
   sort: 0,
   tab: 0,
 });

--- a/front/src/jotai/searchData.ts
+++ b/front/src/jotai/searchData.ts
@@ -23,7 +23,7 @@ const searchDataAtom = atom(
     const newSearchData = { ...prevData };
     Object.entries(inputData).forEach(entry => {
       const [keyName, value] = entry;
-      if (value) {
+      if (value !== undefined) {
         newSearchData[keyName] = value;
       }
     });

--- a/front/src/organisms/CategoryBottomSheet.tsx
+++ b/front/src/organisms/CategoryBottomSheet.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+import { ISortBottomSheet } from '../types/organisms/SortBottomSheet.types';
+import useSearchDataAtom from '../jotai/searchData';
+import ToggleChip from '../atoms/ToggleChip';
+import { CATEGORY_LIST } from '../constant/searchConstant';
+// const SelectBox = (props: ISelectBox) => {
+//   return (
+//     <div
+//       className="flex flex-col justify-center items-center mt-2"
+//       onClick={props.onClick}
+//       onKeyUp={() => {}}
+//       role="button"
+//       tabIndex={0}
+//     >
+//       <p className={`${props.isBold ? 'font-bold' : ''} text-xl mb-1`}>
+//         {props.text}
+//       </p>
+//       <hr className="w-1/3" />
+//     </div>
+//   );
+// };
+
+function CategoryBottomSheet(props: ISortBottomSheet) {
+  const [searchData, setSearchData] = useSearchDataAtom();
+  const modalRef = useRef<HTMLDivElement>(null);
+  const handleClickChip = (idx: number) => {
+    let convertedList = [...searchData.category];
+    if (idx === 0) {
+      convertedList = convertedList.map(() => false);
+    } else {
+      convertedList[0] = false;
+    }
+    convertedList[idx] = !convertedList[idx];
+    setSearchData({ category: convertedList });
+  };
+  const handleModalClose = (e: MouseEvent) => {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      props.onClose();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleModalClose);
+    return () => {
+      document.removeEventListener('mousedown', handleModalClose);
+    };
+  }, []);
+
+  return (
+    <div className="bg-black/30 w-screen h-[100%] absolute top-0 left-0">
+      <div
+        ref={modalRef}
+        className="rounded-t-[40px] bg-white pt-2 pb-5 fixed bottom-0 z-10 w-screen"
+      >
+        <p className="text-center text-xl font-bold text-gray-dark mb-4">
+          카테고리 선택
+        </p>
+        <div className="flex px-[30px] flex-wrap gap-4 ">
+          {CATEGORY_LIST.map((element, idx) => (
+            <ToggleChip
+              dataId={`${idx}`}
+              text={element}
+              onClick={() => handleClickChip(idx)}
+              isClick={searchData.category[idx]}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CategoryBottomSheet;

--- a/front/src/organisms/PolaroidList.tsx
+++ b/front/src/organisms/PolaroidList.tsx
@@ -1,0 +1,5 @@
+function PolaroidList() {
+  return <div>게시글리스트</div>;
+}
+
+export default PolaroidList;

--- a/front/src/organisms/SearchTab.tsx
+++ b/front/src/organisms/SearchTab.tsx
@@ -1,0 +1,36 @@
+import { ITab } from '../types/organisms/SearchTab.types';
+import useSearchDataAtom from '../jotai/searchData';
+// const TAB_TAG = 0;
+// const TAB_REGION = 1;
+// const TAB_ACCOUNT = 2;
+const TAB_NAMES = ['태그', '지역', '계정'];
+
+const Tab = (props: ITab) => {
+  return (
+    <button
+      type="button"
+      className={`${props.isSelected ? 'border-black' : 'border-white'} border-b-2 w-full`}
+      onClick={props.onClick}
+    >
+      {TAB_NAMES[props.tabId]}
+    </button>
+  );
+};
+
+function SearchTab() {
+  const [searchData, setSearchData] = useSearchDataAtom();
+  return (
+    <div className="font-bold text-xl flex justify-around bg-white leading-10">
+      {TAB_NAMES.map((element, idx) => (
+        <Tab
+          isSelected={searchData.tab === idx}
+          onClick={() => setSearchData({ tab: idx })}
+          tabId={idx}
+          key={TAB_NAMES[idx]}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default SearchTab;

--- a/front/src/organisms/SortBottomSheet.tsx
+++ b/front/src/organisms/SortBottomSheet.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import {
+  ISelectBox,
+  ISortBottomSheet,
+} from '../types/organisms/SortBottomSheet.types';
+import useSearchDataAtom from '../jotai/searchData';
+
+const SelectBox = (props: ISelectBox) => {
+  return (
+    <div
+      className="flex flex-col justify-center items-center mt-2"
+      onClick={props.onClick}
+      onKeyUp={() => {}}
+      role="button"
+      tabIndex={0}
+    >
+      <p className={`${props.isBold ? 'font-bold' : ''} text-xl mb-1`}>
+        {props.text}
+      </p>
+      <hr className="w-1/3" />
+    </div>
+  );
+};
+
+function SortBottomSheet(props: ISortBottomSheet) {
+  const [searchData, setSearchData] = useSearchDataAtom();
+  const modalRef = useRef<HTMLDivElement>(null);
+  const handleClickSelectBox = (idx: number) => {
+    setSearchData({ sort: idx });
+    props.onClose();
+  };
+  const handleModalClose = (e: MouseEvent) => {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      props.onClose();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleModalClose);
+    return () => {
+      document.removeEventListener('mousedown', handleModalClose);
+    };
+  }, []);
+  return (
+    <div className="bg-black/30 w-screen h-[100%] absolute top-0 left-0">
+      <div
+        ref={modalRef}
+        className="rounded-t-[40px] bg-white pt-2 pb-5 fixed bottom-0 z-10 w-screen"
+      >
+        <p className="text-center text-xl font-bold text-gray-dark mb-4">
+          정렬 기준 선택
+        </p>
+        {sortList.map((element, idx) => (
+          <SelectBox
+            text={element}
+            id={idx}
+            onClick={() => handleClickSelectBox(idx)}
+            key={element}
+            isBold={idx === searchData.sort}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const sortList = ['최신순', '평점순', 'Yummy순'];
+export default SortBottomSheet;

--- a/front/src/organisms/SortCriteria.tsx
+++ b/front/src/organisms/SortCriteria.tsx
@@ -1,0 +1,85 @@
+/**
+ * SelectSort : 정렬 기준을
+ * @returns
+ */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import { useState } from 'react';
+import SortBottomSheet from './SortBottomSheet';
+import CategoryBottomSheet from './CategoryBottomSheet';
+import useSearchDataAtom from '../jotai/searchData';
+import ToggleChip from '../atoms/ToggleChip';
+import { CATEGORY_LIST, SORT_LIST } from '../constant/searchConstant';
+
+const [SELECT_NONE, SELECT_SORT, SELECT_CATEGORY] = [0, 1, 2];
+
+function SortCriteria() {
+  const [isSelect, setIsSelect] = useState(SELECT_NONE);
+  const [searchData] = useSearchDataAtom();
+  const handleIcon = (type: number) => {
+    if (isSelect === SELECT_NONE) {
+      setIsSelect(type);
+      return;
+    }
+    setIsSelect(SELECT_NONE);
+  };
+  return (
+    <div className="mx-[30px] px-3 bg-white py-3 my-5 flex flex-col gap-2">
+      <div
+        onClick={() => handleIcon(SELECT_SORT)}
+        onKeyUp={() => {}}
+        role="button"
+        tabIndex={0}
+      >
+        {isSelect === SELECT_SORT ? (
+          <FontAwesomeIcon icon={faChevronUp} className="mr-2" />
+        ) : (
+          <FontAwesomeIcon icon={faChevronDown} className="mr-2" />
+        )}
+        {SORT_LIST[searchData.sort]}
+      </div>
+      <div
+        onClick={() => handleIcon(SELECT_CATEGORY)}
+        onKeyUp={() => {}}
+        role="button"
+        tabIndex={0}
+      >
+        {isSelect === SELECT_CATEGORY ? (
+          <FontAwesomeIcon
+            icon={faChevronUp}
+            onClick={() => setIsSelect(SELECT_NONE)}
+            className="mr-2"
+          />
+        ) : (
+          <FontAwesomeIcon
+            icon={faChevronDown}
+            onClick={() => setIsSelect(SELECT_CATEGORY)}
+            className="mr-2"
+          />
+        )}
+        카테고리
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {searchData.category.map(
+          (category, idx) =>
+            category && (
+              <ToggleChip
+                dataId={CATEGORY_LIST[idx]}
+                isClick={category}
+                text={CATEGORY_LIST[idx]}
+                onClick={() => {}}
+              />
+            ),
+        )}
+      </div>
+      {isSelect === SELECT_CATEGORY && (
+        <CategoryBottomSheet onClose={() => setIsSelect(SELECT_NONE)} />
+      )}
+      {isSelect === SELECT_SORT && (
+        <SortBottomSheet onClose={() => setIsSelect(SELECT_NONE)} />
+      )}
+    </div>
+  );
+}
+
+export default SortCriteria;

--- a/front/src/organisms/TodayYum.tsx
+++ b/front/src/organisms/TodayYum.tsx
@@ -1,0 +1,14 @@
+function TodayYum() {
+  return (
+    <div className="rounded bg-white mx-[30px] py-4 px-2 my-5">
+      <p className="base-bold text-center">오늘의 얌</p>
+      <div>
+        <p className="shadow-md bg-secondary-container base-bold my-auto rounded-small py-[5px] px-2.5 border-secondary-container leading-7  border-[1.5px] w-[40px]">
+          한식
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default TodayYum;

--- a/front/src/organisms/UserList.tsx
+++ b/front/src/organisms/UserList.tsx
@@ -1,0 +1,5 @@
+function UserList() {
+  return <div>계정리스트</div>;
+}
+
+export default UserList;

--- a/front/src/pages/MainPage.tsx
+++ b/front/src/pages/MainPage.tsx
@@ -5,11 +5,15 @@
  */
 
 import SelectSearch from '../atoms/SelectSearch';
+import SortCriteria from '../organisms/SortCriteria';
+import TodayYum from '../organisms/TodayYum';
 
 function MainPage() {
   return (
     <div className="bg-background h-screen py-3">
       <SelectSearch />
+      <TodayYum />
+      <SortCriteria />
     </div>
   );
 }

--- a/front/src/pages/RecentSearchPage.tsx
+++ b/front/src/pages/RecentSearchPage.tsx
@@ -63,16 +63,19 @@ function RecentSearchPage() {
     requsetSearch();
   };
   return (
-    <div className="bg-white my-3 mx-[30px] flex gap-4 p-3 flex-wrap rounded">
-      {searchWords.map(element => (
-        <DeletableChip
-          dataId={element.dataId}
-          text={element.text}
-          onSelectClick={() => handleSelectButton(element.text)}
-          deleteSearchWord={() => deleteSearchWord(element.dataId)}
-          key={element.dataId}
-        />
-      ))}
+    <div className="bg-white my-3 mx-[30px] rounded">
+      <p className="base-bold ml-4 pt-4">최근 검색어</p>
+      <div className="flex gap-4 p-3 flex-wrap">
+        {searchWords.map(element => (
+          <DeletableChip
+            dataId={element.dataId}
+            text={element.text}
+            onSelectClick={() => handleSelectButton(element.text)}
+            deleteSearchWord={() => deleteSearchWord(element.dataId)}
+            key={element.dataId}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/front/src/pages/SearchResultPage.tsx
+++ b/front/src/pages/SearchResultPage.tsx
@@ -5,8 +5,22 @@
  * @returns
  */
 
+import SearchTab from '../organisms/SearchTab';
+import useSearchDataAtom from '../jotai/searchData';
+import UserList from '../organisms/UserList';
+import PolaroidList from '../organisms/PolaroidList';
+
+// const TAB_TAG = 0;
+// const TAB_REGION = 1;
+const TAB_ACCOUNT = 2;
 function SearchResultPage() {
-  return <div>asdf</div>;
+  const [{ tab }] = useSearchDataAtom();
+  return (
+    <div>
+      <SearchTab />
+      {tab === TAB_ACCOUNT ? <UserList /> : <PolaroidList />}
+    </div>
+  );
 }
 
 export default SearchResultPage;

--- a/front/src/types/jotai/searchData.types.ts
+++ b/front/src/types/jotai/searchData.types.ts
@@ -1,6 +1,6 @@
 export interface ISearchData {
   keyword: string;
-  category: number;
+  category: boolean[];
   sort: number;
   tab: number;
   [key: string]: any;
@@ -8,7 +8,7 @@ export interface ISearchData {
 
 export interface IUndefindableSearchData {
   keyword?: string;
-  category?: number;
+  category?: boolean[];
   sort?: number;
   tab?: number;
   [key: string]: any;

--- a/front/src/types/organisms/CategoryBottomSheet.types.ts
+++ b/front/src/types/organisms/CategoryBottomSheet.types.ts
@@ -1,0 +1,3 @@
+export interface ISortBottomSheet {
+  onClose: () => void;
+}

--- a/front/src/types/organisms/SearchTab.types.ts
+++ b/front/src/types/organisms/SearchTab.types.ts
@@ -1,0 +1,5 @@
+export interface ITab {
+  tabId: number;
+  onClick: () => void;
+  isSelected: boolean;
+}

--- a/front/src/types/organisms/SortBottomSheet.types.ts
+++ b/front/src/types/organisms/SortBottomSheet.types.ts
@@ -1,0 +1,10 @@
+export interface ISelectBox {
+  text: string;
+  id: number;
+  onClick: () => void;
+  isBold: boolean;
+}
+
+export interface ISortBottomSheet {
+  onClose: () => void;
+}


### PR DESCRIPTION
## 개요 :mag:

- 검색 창을 검색 버튼 눌렀을때 / 누르지 않았을 때로 on/off 시키려 하였으나, 아예 페이지로 분리하는 것이 더 유용해 보여 페이지로 구현
- 메인 페이지 -> 최근 검색어 페이지 -> 검색 결과 페이지로 구분

## 작업사항 :memo:

- 위에 서술한 페이지들 껍데기 구현
- 검색 결과 페이지에서 사용할 탭 구현
- 그외 세부 컴포넌트 (폴라로이트, 계정 등) 미구현
