### PR TITLE
[FE/feat] 마이페이지 구현

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -12,6 +12,11 @@ import SearchResultPage from './pages/SearchResultPage';
 import FilmDetailPage from './pages/FilmDetailPage';
 import UploadFicturesPage from './pages/UploadFicturesPage';
 import CreatePolaroidFilmPage from './pages/CreatePolaroidFilmPage';
+import UserProfilePage from './pages/UserProfilePage';
+// import MyFilmsPage from './pages/MyFilmsPage';
+import HeaderLayout from './layout/HeaderLayout';
+import MyFilmsPage from './pages/MyFilmsPage';
+import UserListPage from './pages/UserListPage';
 
 function App() {
   return (
@@ -19,6 +24,7 @@ function App() {
       <Route element={<NavBarLayout />}>
         <Route path="/" element={<MainPage />} />
         <Route path="/test" element={<FilmDetailPage />} />
+        <Route path="/profile" element={<UserProfilePage />} />
       </Route>
       <Route path="/create-board" element={<NavBarLayout />}>
         <Route path="select-fictures" element={<UploadFicturesPage />} />
@@ -34,6 +40,11 @@ function App() {
       <Route element={<SearchLayout />}>
         <Route path="/recent" element={<RecentSearchPage />} />
         <Route path="/search-result" element={<SearchResultPage />} />
+      </Route>
+      {/* <Route path="/films" element={<MyFilmsPage />} /> */}
+      <Route element={<HeaderLayout />}>
+        <Route path="/write-list" element={<MyFilmsPage />} />
+        <Route path="/user-list" element={<UserListPage />} />
       </Route>
     </Routes>
   );

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -39,6 +39,9 @@
   .base-bold {
     @apply font-bold text-base mb-[18px];
   }
+  .absolute-center {
+    @apply left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2;
+  }
 }
 
 body {

--- a/front/src/jotai/signUpData.ts
+++ b/front/src/jotai/signUpData.ts
@@ -1,6 +1,6 @@
 /**
  * 회원가입에서 관리하는 정보
- * signInDataAtom : initialAtom
+ * signUpDataAtom : initialAtom
  * setEmail : 이메일 갱신 set
  * setCode : 인증코드 갱신
  * plusSignUpLevel : signUp 단계 상향
@@ -10,7 +10,7 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { ISignUpPage } from '../types/pages/SignUpPage.types';
 
-const signInDataAtom = atom<ISignUpPage>({
+const signUpDataAtom = atom<ISignUpPage>({
   email: '',
   password: '',
   confirmPassword: '',
@@ -19,8 +19,8 @@ const signInDataAtom = atom<ISignUpPage>({
   signUpLevel: 0,
 });
 
-const initSignInDataAtom = atom(null, (get, set) => {
-  set(signInDataAtom, {
+const initsignUpDataAtom = atom(null, (get, set) => {
+  set(signUpDataAtom, {
     email: '',
     password: '',
     confirmPassword: '',
@@ -33,76 +33,76 @@ const initSignInDataAtom = atom(null, (get, set) => {
 // setEmail
 const setEmail = atom(null, (get, set, email: string) => {
   const signUpStatus = {
-    ...get(signInDataAtom),
+    ...get(signUpDataAtom),
     email,
   };
-  set(signInDataAtom, signUpStatus);
+  set(signUpDataAtom, signUpStatus);
 });
 // setCode
 const setCode = atom(null, (get, set, code: string) => {
   const signUpStatus = {
-    ...get(signInDataAtom),
+    ...get(signUpDataAtom),
     code,
   };
-  set(signInDataAtom, signUpStatus);
+  set(signUpDataAtom, signUpStatus);
 });
 
 // signUpLevel 증가
 const plusSignUpLevel = atom(null, (get, set) => {
-  const prev = { ...get(signInDataAtom) };
+  const prev = { ...get(signUpDataAtom) };
   const signUpStatus = {
     ...prev,
     signUpLevel: prev.signUpLevel + 1,
   };
-  set(signInDataAtom, signUpStatus);
+  set(signUpDataAtom, signUpStatus);
 });
 
 // signUpLevel 감소
 const minusSignUpLevel = atom(null, (get, set) => {
-  const prev = { ...get(signInDataAtom) };
+  const prev = { ...get(signUpDataAtom) };
   const signUpStatus = {
     ...prev,
     signUpLevel: prev.signUpLevel - 1,
   };
-  set(signInDataAtom, signUpStatus);
+  set(signUpDataAtom, signUpStatus);
 });
 
 // password 등록
 const setPassword = atom(null, (get, set, password: string) => {
   const signUpStatus = {
-    ...get(signInDataAtom),
+    ...get(signUpDataAtom),
     password,
   };
-  set(signInDataAtom, signUpStatus);
+  set(signUpDataAtom, signUpStatus);
 });
 
 // 비밀번호 확인
 const setConfirmPassword = atom(null, (get, set, confirmPassword: string) => {
   const signUpStatus = {
-    ...get(signInDataAtom),
+    ...get(signUpDataAtom),
     confirmPassword,
   };
-  set(signInDataAtom, signUpStatus);
+  set(signUpDataAtom, signUpStatus);
 });
 
 // nickname 등록
 const setNickname = atom(null, (get, set, nickname: string) => {
   const signUpStatus = {
-    ...get(signInDataAtom),
+    ...get(signUpDataAtom),
     nickname,
   };
-  set(signInDataAtom, signUpStatus);
+  set(signUpDataAtom, signUpStatus);
 });
 
 export const useSetEmailAtom = () => useSetAtom(setEmail);
 export const useSetCodeAtom = () => useSetAtom(setCode);
 export const usePlusSignUpLevelAtom = () => useSetAtom(plusSignUpLevel);
 export const useMinusSignUpLevelAtom = () => useSetAtom(minusSignUpLevel);
-export const useSignInDataAtom = () => useAtomValue(signInDataAtom);
+export const useSignUpDataAtom = () => useAtomValue(signUpDataAtom);
 export const useSetPasswordAtom = () => useSetAtom(setPassword);
 export const useSetConfirmPasswordAtom = () => useSetAtom(setConfirmPassword);
 export const useSetNicknameAtom = () => useSetAtom(setNickname);
-export const useInitSignInDataAtom = () => useSetAtom(initSignInDataAtom);
+export const useInitsignUpDataAtom = () => useSetAtom(initsignUpDataAtom);
 
 // 고민 : 여러가지 방법?
 // 1. 지금과 같은 방법

--- a/front/src/jotai/userProfile.ts
+++ b/front/src/jotai/userProfile.ts
@@ -1,0 +1,36 @@
+import { atom, useAtomValue, useSetAtom } from 'jotai';
+import {
+  IProfileImg,
+  IUserProfileContainer,
+} from '../types/organisms/UserProfileContainer.types';
+
+const userProfile = atom<IUserProfileContainer>({
+  nickname: 'yonggkimm',
+  comment: 'ㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇ',
+  profile: undefined,
+  profileFile: null,
+  followerCount: 10000,
+  followingCount: 1,
+});
+
+export const userProfileAtom = () => useAtomValue(userProfile);
+
+const setCommentAtom = atom(null, (get, set, comment: string) => {
+  set(userProfile, { ...get(userProfile), comment });
+});
+
+const setNicknameAtom = atom(null, (get, set, nickname: string) => {
+  set(userProfile, { ...get(userProfile), nickname });
+});
+
+const setProfileImgAtom = atom(null, (get, set, profileImg: IProfileImg) => {
+  set(userProfile, {
+    ...get(userProfile),
+    profile: profileImg.profile,
+    profileFile: profileImg.profileFile,
+  });
+});
+
+export const useSetCommentAtom = () => useSetAtom(setCommentAtom);
+export const useSetNicknameAtom = () => useSetAtom(setNicknameAtom);
+export const useSetProfileImgAtom = () => useSetAtom(setProfileImgAtom);

--- a/front/src/layout/HeaderLayout.tsx
+++ b/front/src/layout/HeaderLayout.tsx
@@ -1,0 +1,15 @@
+import { Outlet, useLocation } from 'react-router-dom';
+import Header from '../atoms/Header';
+
+function HeaderLayout() {
+  const location = useLocation();
+  console.log(location, '레이아웃의 로케이션 확인');
+  return (
+    <div>
+      <Header title={location.state.title} />
+      <Outlet />
+    </div>
+  );
+}
+
+export default HeaderLayout;

--- a/front/src/organisms/EditProfileBasicInfoContainer.tsx
+++ b/front/src/organisms/EditProfileBasicInfoContainer.tsx
@@ -1,0 +1,108 @@
+import { useState, useRef, ChangeEvent } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import {
+  userProfileAtom,
+  useSetCommentAtom,
+  useSetNicknameAtom,
+  useSetProfileImgAtom,
+} from '../jotai/userProfile';
+import InputText from '../atoms/InputText';
+import RectangleButton from '../atoms/RectangleButton';
+import { IEditProfileBasicInfoContainer } from '../types/organisms/EditProfileBasicInfoContainer.types';
+
+function EditProfileBasicInfoContainer(props: IEditProfileBasicInfoContainer) {
+  const userProfile = userProfileAtom();
+  const setNicknameAtom = useSetNicknameAtom();
+  const setCommentAtom = useSetCommentAtom();
+  const setProfileImgAtom = useSetProfileImgAtom();
+  const [nickname, setNickname] = useState(userProfile.nickname);
+  const [comment, setComment] = useState(userProfile.comment);
+  const imgInputRef = useRef<HTMLInputElement>(null);
+
+  const handleSetNickNameValue = (input: string) => {
+    setNickname(input);
+  };
+  const handleSetCommentValue = (input: string) => {
+    setComment(input);
+  };
+
+  const handleSetNicknameButton = () => {
+    // API 요청 후
+    setNicknameAtom(nickname);
+  };
+  const handleCommentButton = () => {
+    // API 요청 후
+    setCommentAtom(comment);
+  };
+  const handleClickUploadButton = () => {
+    imgInputRef.current?.click();
+  };
+  const handleUploadImg = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files?.length) return;
+    const target = e.target.files[0];
+    // API로 등록 후 받은 S3 주소를 profile에 넣을 것
+    setProfileImgAtom({
+      profileFile: target,
+      profile: window.URL.createObjectURL(target),
+    });
+  };
+
+  return (
+    <div>
+      <div className="flex gap-4">
+        <div className="h-[70px] w-[70px] relative flex-[0_0_70px] mt-3">
+          <input
+            type="file"
+            onChange={handleUploadImg}
+            className="hidden"
+            ref={imgInputRef}
+          />
+          <img
+            src={userProfile.profile ?? '/t1.jpg'}
+            alt="프로필 사진 수정 버튼"
+            className="rounded-full opacity-60 h-[70px] w-[70px] object-cover"
+          />
+          <FontAwesomeIcon
+            icon={faPlus}
+            className="absolute absolute-center text-5xl text-gray-dark/80"
+            onClick={handleClickUploadButton}
+          />
+        </div>
+        <div className="w-full">
+          <p className="base-bold mb-2">닉네임</p>
+          <InputText
+            hasSupport
+            placeholder="닉네임"
+            type="text"
+            hasButton
+            value={nickname}
+            setValue={handleSetNickNameValue}
+            onClickUpload={handleSetNicknameButton}
+            isSuccess={-1}
+            failText="중복된 닉네임이 있습니다."
+            successText="닉네임이 변경되었습니다."
+          />
+        </div>
+      </div>
+      <p className="base-bold">한줄 소개</p>
+      <InputText
+        hasSupport={false}
+        placeholder="한줄 소개"
+        type="text"
+        hasButton
+        value={comment}
+        setValue={handleSetCommentValue}
+        onClickUpload={handleCommentButton}
+        customClass="mb-[30px]"
+      />
+      <RectangleButton
+        text="비밀번호 재설정"
+        onClick={props.goNextLevel}
+        customClass="w-full"
+      />
+    </div>
+  );
+}
+
+export default EditProfileBasicInfoContainer;

--- a/front/src/organisms/EditProfileIdentifyUserContainer.tsx
+++ b/front/src/organisms/EditProfileIdentifyUserContainer.tsx
@@ -1,0 +1,34 @@
+/**
+ * EditProfileIdentifyUserContainer
+ * 유저 정보 수정 중, 비밀번호 재설정을 클릭했을 경우 나타나는 영역
+ * 재설정 이전 본인이 맞는지 한 번더 확인을 위해 비밀번호 입력하는 단계
+ */
+
+import { useState } from 'react';
+import InputPassword from '../atoms/InputPassword';
+import RectangleButton from '../atoms/RectangleButton';
+import { IEditProfileIdentifyuserContainer } from '../types/organisms/EditProfileIdentifyUserContainer.types';
+
+function EditProfileIdentifyUserContainer(
+  props: IEditProfileIdentifyuserContainer,
+) {
+  const [password, setPassword] = useState('');
+  return (
+    <div>
+      <p className="text-center font-bold text-2xl mb-6">본인 확인</p>
+      <p className="base-bold mb-5 ml-1">비밀번호를 입력해주세요.</p>
+      <InputPassword
+        setValue={setPassword}
+        value={password}
+        customClass="mb-5"
+      />
+      <RectangleButton
+        text="확인"
+        onClick={props.goNextLevel}
+        customClass="w-full mt-5"
+      />
+    </div>
+  );
+}
+
+export default EditProfileIdentifyUserContainer;

--- a/front/src/organisms/EditProfileModal.tsx
+++ b/front/src/organisms/EditProfileModal.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react';
+import ResetPassword from './ResetPassword';
+import EditProfileFirstContainer from './EditProfileBasicInfoContainer';
+import EditProfileIdentifyUserContainer from './EditProfileIdentifyUserContainer';
+
+function EditProfileModal({ onClose }: { onClose: () => void }) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const modal2Ref = useRef<HTMLDivElement>(null);
+
+  const [modalLevel, setModalLevel] = useState(0);
+
+  const handleModalClose = (e: MouseEvent) => {
+    if (
+      modalRef.current &&
+      !modalRef.current.contains(e.target as Node) &&
+      modal2Ref.current?.contains(e.target as Node)
+    ) {
+      onClose();
+    }
+  };
+
+  const handleModalLevel = (input: number) => {
+    setModalLevel(input);
+  };
+
+  const modalArr = [
+    <EditProfileFirstContainer goNextLevel={() => setModalLevel(1)} />,
+    <EditProfileIdentifyUserContainer goNextLevel={() => setModalLevel(2)} />,
+    <ResetPassword setModalLevel={handleModalLevel} />,
+  ];
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleModalClose);
+    return () => document.removeEventListener('mousedown', handleModalClose);
+  }, []);
+
+  return (
+    <div
+      className="bg-black/30 w-screen h-[100%] absolute top-0 left-0"
+      ref={modal2Ref}
+    >
+      <div
+        ref={modalRef}
+        className="rounded-2xl bg-white shadow-lg p-[15px] absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2 w-10/12"
+      >
+        {modalArr[modalLevel]}
+      </div>
+    </div>
+  );
+}
+
+export default EditProfileModal;

--- a/front/src/organisms/RegistEmail.tsx
+++ b/front/src/organisms/RegistEmail.tsx
@@ -5,8 +5,8 @@ import {
   useSetCodeAtom,
   useSetEmailAtom,
   usePlusSignUpLevelAtom,
-  useSignInDataAtom,
-} from '../jotai/signInData';
+  useSignUpDataAtom,
+} from '../jotai/signUpData';
 import { IRegistEmail } from '../types/organisms/RegistEmail.types';
 
 function Basebold({ text }: { text: string }) {
@@ -14,7 +14,7 @@ function Basebold({ text }: { text: string }) {
 }
 
 function RegistEmail(props: IRegistEmail) {
-  const registData = useSignInDataAtom();
+  const registData = useSignUpDataAtom();
   const setEmail = useSetEmailAtom();
   const setCode = useSetCodeAtom();
   const plusSignUpLevel = usePlusSignUpLevelAtom();

--- a/front/src/organisms/RegistNickname.tsx
+++ b/front/src/organisms/RegistNickname.tsx
@@ -1,10 +1,10 @@
 import InputText from '../atoms/InputText';
 import RectangleButton from '../atoms/RectangleButton';
-import { useSetNicknameAtom, useSignInDataAtom } from '../jotai/signInData';
+import { useSetNicknameAtom, useSignUpDataAtom } from '../jotai/signUpData';
 
 function RegistNickname() {
   const setNickname = useSetNicknameAtom();
-  const registData = useSignInDataAtom();
+  const registData = useSignUpDataAtom();
 
   const handleOverlapCheck = () => {};
 

--- a/front/src/organisms/RegistPassword.tsx
+++ b/front/src/organisms/RegistPassword.tsx
@@ -13,12 +13,12 @@ import {
   useSetPasswordAtom,
   useSetConfirmPasswordAtom,
   usePlusSignUpLevelAtom,
-  useSignInDataAtom,
-} from '../jotai/signInData';
+  useSignUpDataAtom,
+} from '../jotai/signUpData';
 import { IRegistPassword } from '../types/organisms/RegistPassword.types';
 
 function RegistPassword(props: IRegistPassword) {
-  const registData = useSignInDataAtom();
+  const registData = useSignUpDataAtom();
   const setPassword = useSetPasswordAtom();
   const setConfirmPassword = useSetConfirmPasswordAtom();
   const plusSignUpLevelAtom = usePlusSignUpLevelAtom();

--- a/front/src/organisms/ResetPassword.tsx
+++ b/front/src/organisms/ResetPassword.tsx
@@ -1,0 +1,88 @@
+/**
+ * ResetPassword : 비밀번호 재설정 컴포넌트
+ * @returns
+ */
+
+import Swal from 'sweetalert2';
+import { useState } from 'react';
+import InputText from '../atoms/InputText';
+import RectangleButton from '../atoms/RectangleButton';
+import { isRightPassword } from '../util/passwordCheck';
+import InputPassword from '../atoms/InputPassword';
+import { IResetPassword } from '../types/organisms/ResetPassword.types';
+
+function ResetPassword(props: IResetPassword) {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  // const setNickname = useSetNicknameAtom();
+
+  const handleNextButton = () => {
+    // 닉네임 체크?
+    // 비밀번호 체크
+    if (!isRightPassword(password)) {
+      Swal.fire({
+        icon: 'warning',
+        text: '비밀번호가 올바르지 않습니다.',
+        width: '300px',
+        confirmButtonText: '돌아가기',
+        confirmButtonColor: '#787D85',
+      });
+      return;
+    }
+    // 비밀번호 일치성 체크
+    if (handleSuccessOfConfirmPassword(password, confirmPassword) !== 1) {
+      Swal.fire({
+        icon: 'warning',
+        text: '입력한 비밀번호가 다릅니다!',
+        width: '300px',
+        confirmButtonText: '돌아가기',
+        confirmButtonColor: '#787D85',
+      });
+      return;
+    }
+    // 다음 단께로 넘어가는 작업
+    props.setModalLevel(0);
+  };
+
+  return (
+    <div className="flex flex-col justify-center my-5">
+      <p className="text-center font-bold text-2xl mb-6">비밀번호 재설정</p>
+      <p className="base-bold mb-5 ml-1">
+        새로 설정할 비밀번호를 입력해주세요.
+      </p>
+      <InputPassword
+        setValue={setPassword}
+        value={password}
+        customClass="mb-5"
+      />
+      <p className="base-bold ml-1">비밀번호를 다시 입력해주세요.</p>
+      <InputText
+        type="password"
+        hasSupport
+        isSuccess={handleSuccessOfConfirmPassword(password, confirmPassword)}
+        successText="비밀번호가 일치합니다."
+        failText="비밀번호가 일치하지 않습니다."
+        placeholder="비밀번호 확인"
+        setValue={setConfirmPassword}
+        value={confirmPassword}
+      />
+      <RectangleButton
+        text="재설정하기"
+        onClick={handleNextButton}
+        customClass="w-full mt-5"
+      />
+    </div>
+  );
+}
+
+const handleSuccessOfConfirmPassword = (origin: string, target: string) => {
+  if (target.length === 0) {
+    return -1;
+  }
+  if (origin === target) {
+    return 1;
+  }
+  return 0;
+};
+
+export default ResetPassword;

--- a/front/src/organisms/UserProfileContainer.tsx
+++ b/front/src/organisms/UserProfileContainer.tsx
@@ -1,0 +1,88 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faHeart as faHeartFill,
+  faPencil,
+} from '@fortawesome/free-solid-svg-icons';
+import { faHeart } from '@fortawesome/free-regular-svg-icons';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import EditProfileModal from './EditProfileModal';
+import { userProfileAtom } from '../jotai/userProfile';
+
+function UserProfileContainer() {
+  const [isOnEdit, setIsOnEdit] = useState(false);
+  const userProfile = userProfileAtom();
+  const navigate = useNavigate();
+  const handleFollowButton = () => {};
+
+  const handleGoFollowings = () => {
+    navigate('/user-list', { state: { title: '팔로잉 목록' } });
+  };
+  const handleGoFollowers = () => {
+    navigate('/user-list', { state: { title: '팔로워 목록' } });
+  };
+  return (
+    <div className="bg-white rounded-2xl m-[15px] p-[15px]">
+      <div className="flex flex-row items-center justify-between mb-[15px] gap-3">
+        <img
+          src={userProfile.profile}
+          alt="프로필 사진"
+          className="h-[45px] w-[45px] object-cover rounded-full"
+        />
+        <div className="font-ggTitle text-base w-full">
+          <p className="font-bold mb-2">{userProfile.nickname}</p>
+          <p>{userProfile.comment}</p>
+        </div>
+        {DUMMY_ISMINE ? (
+          <FontAwesomeIcon
+            icon={faPencil}
+            className="text-gray-dark mx-1 text-xl"
+            onClick={() => setIsOnEdit(true)}
+          />
+        ) : (
+          <FontAwesomeIcon
+            icon={DUMMY_ISFOLLOW ? faHeartFill : faHeart}
+            className="mr-1 text-primary text-2xl"
+            onClick={handleFollowButton}
+          />
+        )}
+      </div>
+      <hr className="border-gray-dark border-[0.5px] my-[15px]" />
+      <div className="flex justify-around text-center">
+        <div
+          onClick={handleGoFollowers}
+          tabIndex={0}
+          onKeyUp={() => {}}
+          role="button"
+        >
+          <p className="base-bold">팔로워</p>
+          <p className="text-xl">
+            {userProfile.followerCount.toLocaleString()}
+          </p>
+        </div>
+        <div
+          onClick={handleGoFollowings}
+          tabIndex={-1}
+          onKeyUp={() => {}}
+          role="button"
+        >
+          <p className="base-bold">팔로잉</p>
+          <p className="text-xl">
+            {userProfile.followingCount.toLocaleString()}
+          </p>
+        </div>
+      </div>
+      {isOnEdit && (
+        <EditProfileModal
+          onClose={() => {
+            setIsOnEdit(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+const DUMMY_ISMINE = true;
+const DUMMY_ISFOLLOW = true;
+export default UserProfileContainer;

--- a/front/src/pages/MyFilmsPage.tsx
+++ b/front/src/pages/MyFilmsPage.tsx
@@ -1,0 +1,23 @@
+/**
+ * WriteFilmsPage
+ * 글 목록 페이지
+ * @returns
+ */
+
+import { useLocation } from 'react-router-dom';
+// import Header from '../atoms/Header';
+
+import PolaroidList from '../organisms/PolaroidList';
+// import { IMyFilmsPage } from '../types/pages/MyFilmsPage.types';
+
+function MyFilmsPage() {
+  const location = useLocation();
+  const { filmList } = location.state;
+  return (
+    <div>
+      <PolaroidList polaroidList={filmList} />
+    </div>
+  );
+}
+
+export default MyFilmsPage;

--- a/front/src/pages/ResetPasswordPage.tsx
+++ b/front/src/pages/ResetPasswordPage.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 import RegistEmail from '../organisms/RegistEmail';
-import { useSignInDataAtom, useInitSignInDataAtom } from '../jotai/signInData';
+import { useSignUpDataAtom, useInitsignUpDataAtom } from '../jotai/signUpData';
 import RegistPassword from '../organisms/RegistPassword';
 
 function ResetPasswordPage() {
-  const registData = useSignInDataAtom();
-  const setInitRegistData = useInitSignInDataAtom();
+  const registData = useSignUpDataAtom();
+  const setInitRegistData = useInitsignUpDataAtom();
 
   useEffect(() => {
     setInitRegistData();

--- a/front/src/pages/SignUpPage.tsx
+++ b/front/src/pages/SignUpPage.tsx
@@ -1,15 +1,15 @@
 import { useEffect } from 'react';
 import RegistEmail from '../organisms/RegistEmail';
-import { useSignInDataAtom, useInitSignInDataAtom } from '../jotai/signInData';
+import { useSignUpDataAtom, useInitsignUpDataAtom } from '../jotai/signUpData';
 import RegistPassword from '../organisms/RegistPassword';
 import RegistNickname from '../organisms/RegistNickname';
 
 function SignUpPage() {
-  const registData = useSignInDataAtom();
-  const setInitSignInData = useInitSignInDataAtom();
+  const registData = useSignUpDataAtom();
+  const setInitsignUpData = useInitsignUpDataAtom();
 
   useEffect(() => {
-    setInitSignInData();
+    setInitsignUpData();
   }, []);
 
   return (

--- a/front/src/pages/UserListPage.tsx
+++ b/front/src/pages/UserListPage.tsx
@@ -1,0 +1,15 @@
+import { useLocation } from 'react-router-dom';
+import UserList from '../organisms/UserList';
+
+function UserListPage() {
+  const location = useLocation();
+  const { userList } = location.state;
+  console.log(userList);
+  return (
+    <div>
+      <UserList />
+    </div>
+  );
+}
+
+export default UserListPage;

--- a/front/src/pages/UserProfilePage.tsx
+++ b/front/src/pages/UserProfilePage.tsx
@@ -1,0 +1,140 @@
+/**
+ * UserProfilePage : 유저데이터 페이지 조회(마이페이지)
+ *
+ */
+
+// import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import Header from '../atoms/Header';
+import UserProfileContainer from '../organisms/UserProfileContainer';
+import PolaroidFilm from '../organisms/PolaroidFilm';
+import { IPolaroidFilm } from '../types/organisms/PolaroidFilm.types';
+// import { IUserProfileContainer } from '../types/organisms/UserProfileContainer.types';
+
+function UserProfilePage() {
+  // const [userProfile] = useState<IUserProfileContainer>(DUMMY_PROFILE);
+  const navigate = useNavigate();
+
+  const handleGoMyFilms = () => {
+    navigate('/write-list', {
+      state: {
+        title: '작성한 글',
+        filmList: DUMMY_FILMS,
+      },
+    });
+  };
+
+  const handleGoYummyList = () => {
+    navigate('/yummy-list', {
+      state: {
+        title: 'Yummy 목록',
+        filmList: DUMMY_FILMS,
+      },
+    });
+  };
+  return (
+    <div>
+      <Header title="마이페이지" />
+      <UserProfileContainer
+      // comment={userProfile.comment}
+      // followerCount={userProfile.followerCount}
+      // followingCount={userProfile.followingCount}
+      // nickname={userProfile.nickname}
+      // profile={userProfile.profile}
+      />
+      <div
+        className="flex justify-between mx-[15px]"
+        onClick={handleGoMyFilms}
+        tabIndex={0}
+        onKeyUp={() => {}}
+        role="button"
+      >
+        <p className="base-bold ml-2">작성한 글</p>
+        <FontAwesomeIcon icon={faChevronRight} />
+      </div>
+      <div className="flex w-[calc(100%-30px)] overflow-auto gap-4 mx-[15px]">
+        {DUMMY_FILMS.map(element => (
+          <PolaroidFilm
+            firstTag={element.firstTag}
+            imgSrc={element.imgSrc}
+            linkPage={element.linkPage}
+            score={element.score}
+            yummyCount={element.yummyCount}
+          />
+        ))}
+      </div>
+      <div
+        className="flex justify-between mx-[15px] mt-[15px]"
+        onClick={handleGoYummyList}
+        tabIndex={0}
+        onKeyUp={() => {}}
+        role="button"
+      >
+        <p className="base-bold ml-2">Yummy 목록</p>
+        <FontAwesomeIcon icon={faChevronRight} />
+      </div>
+      <div className="flex w-[calc(100%-30px)] overflow-auto gap-4 mx-[15px]">
+        {DUMMY_FILMS.map(element => (
+          <PolaroidFilm
+            firstTag={element.firstTag}
+            imgSrc={element.imgSrc}
+            linkPage={element.linkPage}
+            score={element.score}
+            yummyCount={element.yummyCount}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// const DUMMY_PROFILE = {
+//   email: 'test@test.com',
+//   nickname: 'yonggkimm',
+//   comment: 'ㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇ',
+//   profile: '/t3.jpg',
+//   followerCount: 10000,
+//   followingCount: 1,
+// };
+
+const DUMMY_FILMS: IPolaroidFilm[] = [
+  {
+    firstTag: '테스트테스트테스트테스트테스트테스트테스트테스트테스트',
+    imgSrc: '/logo.svg',
+    score: 4.5,
+    yummyCount: 30,
+    linkPage: '/recent',
+  },
+  {
+    firstTag: '테스트',
+    imgSrc: '/logo.svg',
+    score: 4.5,
+    yummyCount: 30,
+    linkPage: '/recent',
+  },
+  {
+    firstTag: '테스트',
+    imgSrc: '/logo.svg',
+    score: 4.5,
+    yummyCount: 30,
+    linkPage: '/recent',
+  },
+  {
+    firstTag: '테스트',
+    imgSrc: '/logo.svg',
+    score: 4.5,
+    yummyCount: 30,
+    linkPage: '/recent',
+  },
+  {
+    firstTag: '테스트',
+    imgSrc: '/logo.svg',
+    score: 4.5,
+    yummyCount: 30,
+    linkPage: '/recent',
+  },
+];
+
+export default UserProfilePage;

--- a/front/src/types/organisms/EditProfileBasicInfoContainer.types.ts
+++ b/front/src/types/organisms/EditProfileBasicInfoContainer.types.ts
@@ -1,0 +1,3 @@
+export interface IEditProfileBasicInfoContainer {
+  goNextLevel: () => void;
+}

--- a/front/src/types/organisms/EditProfileIdentifyUserContainer.types.ts
+++ b/front/src/types/organisms/EditProfileIdentifyUserContainer.types.ts
@@ -1,0 +1,3 @@
+export interface IEditProfileIdentifyuserContainer {
+  goNextLevel: () => void;
+}

--- a/front/src/types/organisms/ResetPassword.types.ts
+++ b/front/src/types/organisms/ResetPassword.types.ts
@@ -1,0 +1,3 @@
+export interface IResetPassword {
+  setModalLevel: (input: number) => void;
+}

--- a/front/src/types/organisms/UserProfileContainer.types.ts
+++ b/front/src/types/organisms/UserProfileContainer.types.ts
@@ -1,0 +1,11 @@
+export interface IProfileImg {
+  profile: string | undefined;
+  profileFile: File | null;
+}
+
+export interface IUserProfileContainer extends IProfileImg {
+  nickname: string;
+  comment: string;
+  followerCount: number;
+  followingCount: number;
+}

--- a/front/src/types/pages/MyFilmsPage.types.ts
+++ b/front/src/types/pages/MyFilmsPage.types.ts
@@ -1,0 +1,5 @@
+import { IPolaroidFilm } from '../organisms/PolaroidFilm.types';
+
+export interface IMyFilmsPage {
+  filmList: IPolaroidFilm[];
+}


### PR DESCRIPTION
## 개요 :mag:

- 마이페이지(유저 정보 페이지) 및 개인정보 수정 모달 구현

## 작업사항 :memo:

- 헤더를 레이아웃으로 만들 경우, 라우팅되는 페이지에 따라 헤더 제목을 바꾸는 방법을 찾음 -> useLocation 사용하기
   - 추후 기존 레이아웃에 적용할 예정
- 마이페이지 및 개인정보 수정 껍데기만 구현
- 개인정보 수정에서 비밀번호 변경 시, 현재 계정주가 맞는지 다시 한 번 확인하는 절차인 비밀번호 입력 단계 추가 
- 목업 당시 고려하지 않은 사항들 구현
   - 팔로우/팔로잉을 어디서 하는가 ? 유저정보페이지에 유저정보컨테이너에서 선택
   - 팔로우/팔로잉 목록으로 어떻게 연결하는가 ? 유저정보 컨테이너에서 팔로우, 팔로잉 영역 클릭 시 연결
