### PR TITLE
[FE/feat] 유저프로필 페이지 API 연결

### DIFF
--- a/front/src/atoms/Navbar.tsx
+++ b/front/src/atoms/Navbar.tsx
@@ -16,7 +16,10 @@ function Navbar() {
       <Link to="/create-board/select-fictures">
         <FontAwesomeIcon icon={faCirclePlus} />
       </Link>
-      <Link to="/">
+      <Link
+        to="/profile"
+        state={{ memberId: localStorage.getItem('memberId') }}
+      >
         <FontAwesomeIcon icon={faUser} />
       </Link>
       <Link to="/">

--- a/front/src/jotai/userProfile.ts
+++ b/front/src/jotai/userProfile.ts
@@ -5,18 +5,22 @@ import {
 } from '../types/organisms/UserProfileContainer.types';
 
 const userProfile = atom<IUserProfileContainer>({
-  nickname: 'yonggkimm',
-  comment: 'ㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇㅎㅇ',
-  profile: undefined,
+  nickname: '',
+  introduction: '',
+  profile: '/default.png',
   profileFile: null,
   followerCount: 10000,
   followingCount: 1,
+  role: '',
+  email: '',
+  memberId: '',
+  following: false,
 });
 
 export const userProfileAtom = () => useAtomValue(userProfile);
 
 const setCommentAtom = atom(null, (get, set, comment: string) => {
-  set(userProfile, { ...get(userProfile), comment });
+  set(userProfile, { ...get(userProfile), introduction: comment });
 });
 
 const setNicknameAtom = atom(null, (get, set, nickname: string) => {
@@ -26,11 +30,30 @@ const setNicknameAtom = atom(null, (get, set, nickname: string) => {
 const setProfileImgAtom = atom(null, (get, set, profileImg: IProfileImg) => {
   set(userProfile, {
     ...get(userProfile),
-    profile: profileImg.profile,
+    profile: profileImg.profile ?? '/default.png',
     profileFile: profileImg.profileFile,
   });
 });
 
+const setProfileAtom = atom(
+  null,
+  (get, set, userInfo: IUserProfileContainer) => {
+    set(userProfile, {
+      ...get(userProfile),
+      nickname: userInfo.nickname,
+      introduction: userInfo.introduction,
+      profile: userInfo.profile,
+      followerCount: userInfo.followerCount,
+      followingCount: userInfo.followingCount,
+      role: userInfo.role,
+      email: userInfo.email,
+      memberId: userInfo.memberId,
+      following: userInfo.following,
+    });
+  },
+);
+
 export const useSetCommentAtom = () => useSetAtom(setCommentAtom);
 export const useSetNicknameAtom = () => useSetAtom(setNicknameAtom);
 export const useSetProfileImgAtom = () => useSetAtom(setProfileImgAtom);
+export const useSetProfileAtom = () => useSetAtom(setProfileAtom);

--- a/front/src/organisms/EditProfileIdentifyUserContainer.tsx
+++ b/front/src/organisms/EditProfileIdentifyUserContainer.tsx
@@ -5,14 +5,30 @@
  */
 
 import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import InputPassword from '../atoms/InputPassword';
 import RectangleButton from '../atoms/RectangleButton';
 import { IEditProfileIdentifyuserContainer } from '../types/organisms/EditProfileIdentifyUserContainer.types';
+import { fetchPostConfirmPassword } from '../services/userService';
 
 function EditProfileIdentifyUserContainer(
   props: IEditProfileIdentifyuserContainer,
 ) {
   const [password, setPassword] = useState('');
+  const { mutate } = useMutation({
+    mutationFn: (request: string) => fetchPostConfirmPassword(request),
+    onSuccess: response => {
+      console.log('비밀번호 확인 결과', response);
+      if (response) {
+        props.goNextLevel();
+      }
+    },
+    // NOTICE! 비밀번호 일치하지 않을 경우 401에러 발생
+  });
+
+  const handleNextButton = () => {
+    mutate(password);
+  };
   return (
     <div>
       <p className="text-center font-bold text-2xl mb-6">본인 확인</p>
@@ -24,7 +40,7 @@ function EditProfileIdentifyUserContainer(
       />
       <RectangleButton
         text="확인"
-        onClick={props.goNextLevel}
+        onClick={handleNextButton}
         customClass="w-full mt-5"
       />
     </div>

--- a/front/src/organisms/ResetPassword.tsx
+++ b/front/src/organisms/ResetPassword.tsx
@@ -5,15 +5,25 @@
 
 import Swal from 'sweetalert2';
 import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import InputText from '../atoms/InputText';
 import RectangleButton from '../atoms/RectangleButton';
 import { isRightPassword } from '../util/passwordCheck';
 import InputPassword from '../atoms/InputPassword';
 import { IResetPassword } from '../types/organisms/ResetPassword.types';
+import { fetchPatchPassword } from '../services/userService';
 
 function ResetPassword(props: IResetPassword) {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const { mutate } = useMutation({
+    mutationFn: (request: string) => fetchPatchPassword(request),
+    onSuccess: res => {
+      if (res) {
+        props.setModalLevel(0);
+      }
+    },
+  });
   // const setNickname = useSetNicknameAtom();
 
   const handleNextButton = () => {
@@ -41,7 +51,7 @@ function ResetPassword(props: IResetPassword) {
       return;
     }
     // 다음 단께로 넘어가는 작업
-    props.setModalLevel(0);
+    mutate(password);
   };
 
   return (

--- a/front/src/organisms/UserList.tsx
+++ b/front/src/organisms/UserList.tsx
@@ -2,7 +2,6 @@ import { IUserList } from '../types/organisms/UserList';
 import SearchAccountContainer from './SearchAccountContainer';
 
 function UserList(props: IUserList) {
-  // const userList = DUMMY_ACCOUNT;
   return (
     <div className="px-[30px] mt-2 flex flex-col gap-5">
       {props.userList.map(element => (

--- a/front/src/organisms/UserProfileContainer.tsx
+++ b/front/src/organisms/UserProfileContainer.tsx
@@ -11,15 +11,28 @@ import { userProfileAtom } from '../jotai/userProfile';
 
 function UserProfileContainer() {
   const [isOnEdit, setIsOnEdit] = useState(false);
+
   const userProfile = userProfileAtom();
   const navigate = useNavigate();
   const handleFollowButton = () => {};
 
   const handleGoFollowings = () => {
-    navigate('/user-list', { state: { title: '팔로잉 목록' } });
+    navigate('/user-list', {
+      state: {
+        title: '팔로잉 목록',
+        type: 'following',
+        memberId: userProfile.memberId,
+      },
+    });
   };
   const handleGoFollowers = () => {
-    navigate('/user-list', { state: { title: '팔로워 목록' } });
+    navigate('/user-list', {
+      state: {
+        title: '팔로워 목록',
+        type: 'follower',
+        memberId: userProfile.memberId,
+      },
+    });
   };
   return (
     <div className="bg-white rounded-2xl m-[15px] p-[15px]">
@@ -31,9 +44,9 @@ function UserProfileContainer() {
         />
         <div className="font-ggTitle text-base w-full">
           <p className="font-bold mb-2">{userProfile.nickname}</p>
-          <p>{userProfile.comment}</p>
+          <p className="h-6">{userProfile.introduction}</p>
         </div>
-        {DUMMY_ISMINE ? (
+        {userProfile.memberId === localStorage.getItem('memberId') ? (
           <FontAwesomeIcon
             icon={faPencil}
             className="text-gray-dark mx-1 text-xl"
@@ -83,6 +96,5 @@ function UserProfileContainer() {
   );
 }
 
-const DUMMY_ISMINE = true;
 const DUMMY_ISFOLLOW = true;
 export default UserProfileContainer;

--- a/front/src/pages/UserListPage.tsx
+++ b/front/src/pages/UserListPage.tsx
@@ -1,53 +1,35 @@
-// import { useLocation } from 'react-router-dom';
-import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useMemo } from 'react';
 import UserList from '../organisms/UserList';
-import useIntersect from '../util/useIntersect';
 import { IUserThumbnail } from '../types/organisms/UserList';
+import {
+  fetchGetFollowerList,
+  fetchGetFollowingList,
+} from '../services/userService';
+import useInfiniteQueryProduct from '../util/useInfiniteQueryProduct';
 
 function UserListPage() {
-  // const location = useLocation();
-  const [userList, setUserList] = useState<IUserThumbnail[]>(DUMMY_ACCOUNT);
-  // const { userList } = location.state;
-  const [, setRef] = useIntersect(async (entry, observer) => {
-    // API 결과에 따라 hasNext 결정
-    const hasNext = true;
-    const newList = userList.concat(JSON.parse(JSON.stringify(userList)));
-    setUserList(newList);
-    observer.unobserve(entry.target);
-    return hasNext;
-  }, {});
-  console.log(userList);
+  const locationState = useLocation().state;
+  const [, setRef, data, isPending] = useInfiniteQueryProduct(
+    {
+      constant: locationState.type,
+      variables: [],
+      stringVariables: [locationState.memberId],
+    },
+    () =>
+      locationState.type === 'following'
+        ? fetchGetFollowingList
+        : fetchGetFollowerList,
+    {},
+  );
+
+  const product: IUserThumbnail[] = useMemo(() => {
+    console.log('우에에에', data, locationState);
+    return data as IUserThumbnail[];
+  }, [data]);
   return (
-    <div>
-      <UserList userList={userList} setRef={setRef} />
-    </div>
+    <div>{!isPending && <UserList userList={product} setRef={setRef} />}</div>
   );
 }
-const DUMMY_ACCOUNT = [
-  {
-    nickname: '닉네임',
-    imgSrc: '/logo.svg',
-    comment: '테스트입니다.',
-  },
-  {
-    nickname: '닉네임',
-    imgSrc: '/logo.svg',
-    comment: '테스트입니다.',
-  },
-  {
-    nickname: '닉네임',
-    imgSrc: '/logo.svg',
-    comment: '테스트입니다.',
-  },
-  {
-    nickname: '닉네임',
-    imgSrc: '/logo.svc',
-    comment: '테스트입니다.',
-  },
-  {
-    nickname: '닉네임',
-    imgSrc: '/logo.svc',
-    comment: '테스트입니다.',
-  },
-];
+
 export default UserListPage;

--- a/front/src/pages/UserProfilePage.tsx
+++ b/front/src/pages/UserProfilePage.tsx
@@ -3,7 +3,7 @@
  *
  */
 
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { useQuery } from '@tanstack/react-query';
@@ -15,10 +15,24 @@ import {
   fetchGetWrittenBoard,
   fetchGetYummyBoard,
 } from '../services/boardService';
+import { fetchGetUserInfo } from '../services/userService';
+import { useSetProfileAtom } from '../jotai/userProfile';
 
 function UserProfilePage() {
   const DUMMY_MEMBER_ID = '80ad8672-3501-431f-8a9a-0d0f1c02f2c3';
+  const locationState = useLocation().state;
+  const setProfile = useSetProfileAtom();
   const navigate = useNavigate();
+  const { data: userProfile, isSuccess: isProfileSuccess } = useQuery({
+    queryKey: ['userProfile', locationState.memberId],
+    queryFn: () => fetchGetUserInfo(locationState.memberId),
+    staleTime: 500000,
+  });
+
+  if (isProfileSuccess) {
+    console.log('ㅅㅂㅂㅂㅂㅂㅂㅂㅂㅂ', userProfile);
+    setProfile(userProfile);
+  }
   const { data: yummyList, isSuccess: isYummySuccess } = useQuery({
     queryKey: ['yummyBoardList', DUMMY_MEMBER_ID],
     queryFn: () =>
@@ -31,6 +45,7 @@ function UserProfilePage() {
       fetchGetWrittenBoard({ pageParam: 0, content: DUMMY_MEMBER_ID }),
     staleTime: 500000,
   });
+  console.log('상태태', locationState);
   const handleGoMyFilms = () => {
     navigate('/write-list', {
       state: {
@@ -52,7 +67,9 @@ function UserProfilePage() {
   };
   return (
     <div>
-      <Header title="마이페이지" />
+      <Header
+        title={`${localStorage.getItem('memberId') === locationState?.memberId ? '마이페이지' : '프로필페이지'}`}
+      />
       <UserProfileContainer />
       <div
         className="flex justify-between mx-[15px]"

--- a/front/src/services/userService.ts
+++ b/front/src/services/userService.ts
@@ -3,6 +3,7 @@
  */
 import axios from 'axios';
 import {
+  IGetFollowingListRequest,
   IPostCodeRequest,
   ISignUpRequest,
   ISigninRequest,
@@ -205,4 +206,200 @@ export const fetchPostResetPassword = async (request: string) => {
   const response = await axios.post(url, request);
   console.log('로그아웃 결과', response);
   return response.data;
+};
+
+/// //////////////////////////////////////// 프로필
+/**
+ * fetchGetUserInfo : 유저 프로필 정보에서 사용할 유저 정보 가져오기
+ * @param memberId
+ * @returns
+ */
+export const fetchGetUserInfo = async (memberId: string) => {
+  const accessToken = localStorage.getItem('token');
+  if (!accessToken) return false;
+  const url = `${API_URL}/api/members/${memberId}`;
+
+  const response = await axios.get(url, {
+    withCredentials: true,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  return response.data.result;
+};
+
+/**
+ * fetchPatchEditNickname : 닉네임 변경 patch 요청
+ * @param nickname
+ * @returns
+ */
+export const fetchPatchEditNickname = async (nickname: string) => {
+  const accessToken = localStorage.getItem('token');
+  if (!accessToken) return false;
+  const url = `${API_URL}/api/members/nicknames`;
+
+  const formData = new FormData();
+  formData.append('nickname', nickname);
+  const response = await axios.patch(
+    url,
+    { nickname },
+    {
+      withCredentials: true,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  return response.data.message === '요청이 완료되었습니다.';
+};
+
+/**
+ * fetchPatchEditIntroduction : 소개글 변경 patch 요청
+ * @param introduction
+ * @returns
+ */
+export const fetchPatchEditIntroduction = async (introduction: string) => {
+  const accessToken = localStorage.getItem('token');
+  if (!accessToken) return false;
+  const url = `${API_URL}/api/members/introductions`;
+
+  const response = await axios.patch(
+    url,
+    { introduction },
+    {
+      withCredentials: true,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  return response.data.message === '요청이 완료되었습니다.';
+};
+
+/**
+ * fetchPostEditProfileImg : 프로필 사진 갱신 post 요청
+ * @param profile
+ * @returns
+ */
+export const fetchPostEditProfileImg = async (profile: File) => {
+  const accessToken = localStorage.getItem('token');
+  if (!accessToken) return false;
+
+  const url = `${API_URL}/api/members/profiles`;
+
+  const formData = new FormData();
+  formData.append('profile', profile);
+
+  const response = await axios.post(url, formData, {
+    withCredentials: true,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  return response.data.message === '요청이 완료되었습니다.';
+};
+
+/**
+ * fetchPostConfirmPassword : 비밀번호 재설정 과정에서 비밀번호 확인
+ * @param password
+ * @returns
+ */
+export const fetchPostConfirmPassword = async (password: string) => {
+  const accessToken = localStorage.getItem('token');
+  if (!accessToken) return false;
+
+  const url = `${API_URL}/api/auth/verify/password`;
+
+  const formData = new FormData();
+  formData.append('password', password);
+
+  const response = await axios.post(url, formData, {
+    withCredentials: true,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  return response.data.message === '요청이 완료되었습니다.';
+};
+
+/**
+ * fetchPatchPassword : 비밀번호 재설정 과정에서 비밀번호 확인
+ * @param password: 변경된 비밀번호
+ * @returns
+ */
+export const fetchPatchPassword = async (password: string) => {
+  const accessToken = localStorage.getItem('token');
+  if (!accessToken) return false;
+
+  const url = `${API_URL}/api/members/passwords`;
+
+  const response = await axios.patch(
+    url,
+    { password },
+    {
+      withCredentials: true,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  return response.data.message === '요청이 완료되었습니다.';
+};
+
+/**
+ * fetchGetFollowerList : 유저를 팔로우한 리스트 요청
+ * @param request
+ * @returns
+ */
+export const fetchGetFollowerList = async (
+  request: IGetFollowingListRequest,
+) => {
+  const accessToken = localStorage.getItem('token');
+  if (!accessToken) return false;
+
+  const url = `${API_URL}/api/members/${request.content}/followers`;
+
+  const response = await axios.get(url, {
+    withCredentials: true,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    params: {
+      page: request.pageParam,
+    },
+  });
+
+  return response.data.result;
+};
+
+/**
+ * fetchGetFollowingList : 유저가 팔로잉 한 리스트 요청
+ * @param request
+ * @returns
+ */
+export const fetchGetFollowingList = async (
+  request: IGetFollowingListRequest,
+) => {
+  const accessToken = localStorage.getItem('token');
+  if (!accessToken) return false;
+
+  const url = `${API_URL}/api/members/${request.content}/followings`;
+
+  console.log('리퀘ㅔㅔㅔㅔㅔㅔㅔㅔㅔㅔㅔ스트', url);
+  const response = await axios.get(url, {
+    withCredentials: true,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    params: {
+      page: request.pageParam,
+    },
+  });
+  console.log('요청 결곽ㄱㄱㄱㄱㄱ', response);
+  return response.data.result;
 };

--- a/front/src/types/organisms/UserProfileContainer.types.ts
+++ b/front/src/types/organisms/UserProfileContainer.types.ts
@@ -5,7 +5,12 @@ export interface IProfileImg {
 
 export interface IUserProfileContainer extends IProfileImg {
   nickname: string;
-  comment: string;
+  memberId: string;
+  profile: string;
+  role: string;
+  following: boolean;
+  introduction: string;
   followerCount: number;
   followingCount: number;
+  email: string;
 }

--- a/front/src/types/services/userService.ts
+++ b/front/src/types/services/userService.ts
@@ -13,3 +13,8 @@ export interface ISigninRequest {
   email: string;
   password: string;
 }
+
+export interface IGetFollowingListRequest {
+  pageParam: number;
+  content: string;
+}


### PR DESCRIPTION
## 개요 :mag:

- 유저프로필 페이지 API 연결

## 작업사항 :memo:

- 로그인한 사람인지, 아닌지에 따라 헤더 텍스트 변경
- 유저프로필 페이지에 연관된 API 연결
- 팔로잉, 팔로워 목록은 DB에 데이터가 없어 테스트는 아직 못했음, 게시글 상세 API 연결 후 테스트 예정
