### PR TITLE
[FE/feat] 글 정렬 기준 및 카테고리 추가

### DIFF
--- a/front/src/constant/searchConstant.ts
+++ b/front/src/constant/searchConstant.ts
@@ -22,3 +22,4 @@ export const CATEGORY_MAP: { [key: string]: any } = {
 };
 
 export const SORT_LIST = ['최신순', '평점순', 'Yummy순'];
+export const SORT_LIST_EN = ['new', 'rating', 'yummy'];

--- a/front/src/pages/MainPage.tsx
+++ b/front/src/pages/MainPage.tsx
@@ -12,11 +12,32 @@ import { IPolaroidFilm } from '../types/organisms/PolaroidFilm.types';
 import { fetchGetBoardList } from '../services/boardService';
 import useInfiniteQueryProduct from '../util/useInfiniteQueryProduct';
 import { IPageableResponse } from '../types/services/boardService';
+import useSearchDataAtom from '../jotai/searchData';
+import { SORT_LIST_EN } from '../constant/searchConstant';
+// import { fetchPostRefreshToken } from '../services/userService';
+
+const getCategories = (input: boolean[]) => {
+  const categories: number[] = [];
+  input.forEach((element, idx) => {
+    if (element) {
+      categories.push(idx);
+    }
+  });
+  if (categories.length === 0) {
+    categories.push(0);
+  }
+  return categories;
+};
 
 function MainPage() {
   const [isShowModal, setIsShowModal] = useState(false);
+  const [searchData] = useSearchDataAtom();
   const [, setRef, data] = useInfiniteQueryProduct(
-    { constant: 'boardList', variables: [] },
+    {
+      constant: 'boardList',
+      variables: getCategories(searchData.category),
+      stringVariables: [SORT_LIST_EN[searchData.sort]],
+    },
     () => fetchGetBoardList,
     {},
   );
@@ -41,6 +62,9 @@ function MainPage() {
   return (
     <div className="bg-background  py-3">
       <SelectSearch />
+      {/* <button type="button" onClick={() => fetchPostRefreshToken()}>
+        test
+      </button> */}
       <TodayYum
         closeModal={() => setIsShowModal(false)}
         openModal={() => setIsShowModal(true)}

--- a/front/src/services/boardService.ts
+++ b/front/src/services/boardService.ts
@@ -2,11 +2,12 @@ import axios from 'axios';
 import { ICreateFilm } from '../types/jotai/createFile.types';
 import {
   IAddBoard,
+  IGetBoardListParams,
   IGetBoardListRequest,
   IGetPageableListRequest,
   // IGetWrittenBoardListRequest,
 } from '../types/services/boardService';
-import { CATEGORY_LIST } from '../constant/searchConstant';
+import { CATEGORY_LIST, SORT_LIST_EN } from '../constant/searchConstant';
 import { TIME_LIST } from '../constant/createFilmConstant';
 import {
   IUpdateBoardRequest,
@@ -36,8 +37,8 @@ const DEFAULT_CREATE_BOARD: IAddBoard = {
  * @returns
  */
 export const fetchPostAddBoard = async (input: ICreateFilm) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards`;
   const request: IAddBoard = { ...DEFAULT_CREATE_BOARD };
@@ -74,7 +75,7 @@ export const fetchPostAddBoard = async (input: ICreateFilm) => {
 
   const response = await axios.post(url, request, {
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      // Authorization: `Bearer ${accessToken}`,
       'Content-Type': "'multipart/form-data'",
     },
     withCredentials: true,
@@ -88,16 +89,16 @@ export const fetchPostAddBoard = async (input: ICreateFilm) => {
  * @returns
  */
 export const fetchGetBoardDetail = async (boardId: string) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards/${boardId}`;
 
   const response = await axios.get(url, {
     withCredentials: true,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
   });
 
   console.log('글 상세 조회 결과', response, boardId);
@@ -106,21 +107,34 @@ export const fetchGetBoardDetail = async (boardId: string) => {
 
 /**
  * fetchGetBoardList : 메인 화면 게시글 목록, 현재 분류 조건에 따른 결과가 백API로 미구현임
- * @param boardId
+ * @param variables : 카테고리 목록, content : 정렬기준
  * @returns
  */
 export const fetchGetBoardList = async (request: IGetBoardListRequest) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards`;
   console.log('이거외않변함', request.pageParam);
+  const params: IGetBoardListParams = {
+    page: 0,
+    category: CATEGORY_LIST.en[0],
+    sortBy: SORT_LIST_EN[0],
+  };
+
+  params.page = request.pageParam;
+  if (request.variables) {
+    params.category = CATEGORY_LIST.en[request.variables[0]];
+  }
+  if (request.content) {
+    params.sortBy = request.content;
+  }
   const response = await axios.get(url, {
     withCredentials: true,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-    params: { page: request.pageParam },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
+    params,
   });
 
   console.log('글 목록 조회 결과', response, request);
@@ -133,15 +147,15 @@ export const fetchGetBoardList = async (request: IGetBoardListRequest) => {
  * @returns
  */
 export const fetchGetSearchBoard = async (request: IGetPageableListRequest) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
   console.log('리퀘스트 확인', request);
   const url = `${API_URL}/api/boards/search`;
   const response = await axios.get(url, {
     withCredentials: true,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
     params: { page: request.pageParam, content: request.content },
   });
 
@@ -158,15 +172,15 @@ export const fetchGetSearchBoard = async (request: IGetPageableListRequest) => {
 export const fetchGetWrittenBoard = async (
   request: IGetPageableListRequest,
 ) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
   console.log('리퀘스트 확인', request);
   const url = `${API_URL}/api/boards/members/${request.content}`;
   const response = await axios.get(url, {
     withCredentials: true,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
     params: { page: request.pageParam },
   });
 
@@ -181,15 +195,15 @@ export const fetchGetWrittenBoard = async (
  * @returns
  */
 export const fetchGetYummyBoard = async (request: IGetPageableListRequest) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
   console.log('리퀘스트 확인', request);
   const url = `${API_URL}/api/boards/members/${request.content}/yummys`;
   const response = await axios.get(url, {
     withCredentials: true,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
     params: { page: request.pageParam },
   });
 
@@ -203,15 +217,15 @@ export const fetchGetYummyBoard = async (request: IGetPageableListRequest) => {
  * @returns
  */
 export const fetchGetTodayYummys = async (isTop: boolean) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards/yummys${isTop ? '/top' : ''}`;
   const response = await axios.get(url, {
     withCredentials: true,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
   });
 
   if (isTop) {
@@ -228,15 +242,15 @@ export const fetchGetTodayYummys = async (isTop: boolean) => {
  * @returns
  */
 export const fetchPostAddYummy = async (boardId: string) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards/${boardId}/yummys`;
 
   const response = await axios.post(url, null, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
     withCredentials: true,
   });
   return response.data;
@@ -248,15 +262,15 @@ export const fetchPostAddYummy = async (boardId: string) => {
  * @returns
  */
 export const fetchDeleteYummy = async (boardId: string) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards/${boardId}/yummys`;
 
   const response = await axios.delete(url, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
     withCredentials: true,
   });
   return response.data;
@@ -268,8 +282,8 @@ export const fetchDeleteYummy = async (boardId: string) => {
  * @returns
  */
 export const fetchPatchFilm = async (input: IUpdateBoardRequest) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards/${input.boardId}`;
   const request: IUpdateBoardRequestBody = { ...input };
@@ -287,24 +301,24 @@ export const fetchPatchFilm = async (input: IUpdateBoardRequest) => {
   });
 
   const response = await axios.post(url, body, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
     withCredentials: true,
   });
   return response.data;
 };
 
 export const fetchDeleteFilm = async (boardId: string) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards/${boardId}`;
 
   const response = await axios.delete(url, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
     withCredentials: true,
   });
   return response.data;

--- a/front/src/services/commentService.ts
+++ b/front/src/services/commentService.ts
@@ -5,16 +5,16 @@ const API_URL = process.env.REACT_APP_LOCAL_URL;
 // const url = process.env.REACT_APP_SERVER_URL;
 
 export const fetchGetCommentList = async (request: IGetPageableListRequest) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards/${request.content}/comments`;
 
   const response = await axios.get(url, {
     withCredentials: true,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
     params: {
       page: request.pageParam,
     },
@@ -27,8 +27,8 @@ export const fetchPostAddComment = async (request: {
   content: string;
   boardId: string;
 }) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards/${request.boardId}/comments`;
 
@@ -40,9 +40,9 @@ export const fetchPostAddComment = async (request: {
     { content: request.content },
     {
       withCredentials: true,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
+      // headers: {
+      //   Authorization: `Bearer ${accessToken}`,
+      // },
     },
   );
 
@@ -50,16 +50,16 @@ export const fetchPostAddComment = async (request: {
 };
 
 export const fetchDeleteComment = async (commentId: number) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards/comments/${commentId}`;
 
   const response = await axios.delete(url, {
     withCredentials: true,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+    // headers: {
+    //   Authorization: `Bearer ${accessToken}`,
+    // },
   });
 
   return response.data;
@@ -69,8 +69,8 @@ export const fetchPatchEditComment = async (request: {
   content: string;
   commentId: number;
 }) => {
-  const accessToken = localStorage.getItem('token');
-  if (!accessToken) return false;
+  // const accessToken = localStorage.getItem('token');
+  // if (!accessToken) return false;
 
   const url = `${API_URL}/api/boards/comments/${request.commentId}`;
 
@@ -79,9 +79,9 @@ export const fetchPatchEditComment = async (request: {
     { content: request.content },
     {
       withCredentials: true,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
+      // headers: {
+      //   Authorization: `Bearer ${accessToken}`,
+      // },
     },
   );
 

--- a/front/src/types/services/boardService.ts
+++ b/front/src/types/services/boardService.ts
@@ -14,8 +14,14 @@ export interface IAddBoard {
 
 export interface IGetBoardListRequest {
   pageParam: number;
-  categories?: number[];
-  sort?: number;
+  variables?: number[];
+  content?: string;
+}
+
+export interface IGetBoardListParams {
+  page: number;
+  category: string;
+  sortBy: string;
 }
 
 export interface IGetPageableListRequest {

--- a/front/src/util/useInfiniteQueryProduct.tsx
+++ b/front/src/util/useInfiniteQueryProduct.tsx
@@ -33,7 +33,11 @@ const useInfiniteQueryProduct = (
         queryKey.stringVariables,
       ],
       queryFn: ({ pageParam }) =>
-        queryFunction({ pageParam, content: queryKey.stringVariables?.[0] }),
+        queryFunction({
+          pageParam,
+          content: queryKey.stringVariables?.[0],
+          variables: queryKey.variables,
+        }),
       initialPageParam: 0,
       getNextPageParam: lastPage => {
         return lastPage.last ? null : lastPage.number + 1;


### PR DESCRIPTION
## 개요 :mag:

- 정렬순, 카테고리에 따른 글 목록 API 기능 반영

## 작업사항 :memo:

- 기존에 정렬순, 카테고리에 따른 글 목록 기능이 없어 최신순, 모든 카테고리 기준으로 게시글이 나왔음
- 수정한 API 기반으로 적용
- 로컬스토리지에서 액세스토큰을 가져오는 API 요청들 수정
